### PR TITLE
feat: multi-period sleep (calcSleepPeriods) — naps as shorter sleeps

### DIFF
--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -7,7 +7,7 @@ import { calcRestingHR } from '../resting';
 import { calcStrain } from '../strain';
 import { calcHrZones } from '../zones';
 import { calcCalories } from '../calories';
-import { calcSleep } from '../sleep';
+import { calcSleep, calcSleepPeriods } from '../sleep';
 import { calcSleepRegularity } from '../regularity';
 import { detectSessions } from '../sessions';
 import { calcHrRecovery, calcRecovery } from '../recovery';
@@ -214,6 +214,49 @@ console.log('--- §5 calcSleep ---');
   const g = calcSleep(giant, baseline);
   assert(g.in_bed_min <= 14 * 60,
     `plausibility: main-sleep period capped at ~14h (got ${g.in_bed_min})`);
+}
+
+// ── §5b calcSleepPeriods (multi-period; naps = shorter sleeps) ───────────────
+console.log('--- §5b calcSleepPeriods ---');
+{
+  // A main night (200 min) + a separate afternoon nap (40 min), split by a long
+  // awake daytime stretch. v2 must return TWO periods, longest flagged is_main.
+  const day: Minute[] = [];
+  for (let i = 0; i < 5; i++) day.push(min(i * 60, 70, 2000));        // awake before
+  for (let i = 5; i < 205; i++) day.push(min(i * 60, 45, 50));        // 200-min night (asleep)
+  for (let i = 205; i < 305; i++) day.push(min(i * 60, 75, 2500));    // 100-min awake daytime (long gap)
+  for (let i = 305; i < 345; i++) day.push(min(i * 60, 48, 50));      // 40-min afternoon nap (asleep)
+  for (let i = 345; i < 350; i++) day.push(min(i * 60, 72, 2000));    // awake after
+  const v2 = calcSleepPeriods(day, baseline);
+  assert(v2.periods.length === 2, `two sleep periods detected (got ${v2.periods.length})`);
+  const mainP = v2.periods[v2.main_idx ?? -1];
+  assert(mainP != null && mainP.is_main === true, 'main period flagged is_main');
+  assert(mainP.duration_min >= 195, `main period ≈ 200 min (got ${mainP?.duration_min})`);
+  const napP = v2.periods.find((p) => !p.is_main);
+  assert(napP != null && napP.duration_min >= 30 && napP.duration_min <= 45,
+    `nap treated as a shorter sleep ≈ 40 min, edge-trimmed (got ${napP?.duration_min})`);
+  assert(v2.total_asleep_min >= 228, `total asleep sums both periods (got ${v2.total_asleep_min})`);
+  assert(v2.periods.every((p) => p.confidence >= 0 && p.confidence <= 1), 'per-period confidence in [0,1]');
+
+  // Single night → exactly one period (backward-consistent with calcSleep).
+  const oneNight: Minute[] = [];
+  for (let i = 0; i < 5; i++) oneNight.push(min(i * 60, 70, 2000));
+  for (let i = 5; i < 205; i++) oneNight.push(min(i * 60, 45, 50));
+  for (let i = 205; i < 210; i++) oneNight.push(min(i * 60, 72, 2000));
+  const one = calcSleepPeriods(oneNight, baseline);
+  assert(one.periods.length === 1 && one.periods[0].is_main, 'single night → one main period');
+
+  // Micro-doze (< 15 min) is discarded, not surfaced as a period.
+  const micro: Minute[] = [];
+  for (let i = 0; i < 5; i++) micro.push(min(i * 60, 70, 2000));
+  for (let i = 5; i < 13; i++) micro.push(min(i * 60, 45, 50));        // 8-min doze
+  for (let i = 13; i < 20; i++) micro.push(min(i * 60, 72, 2000));
+  const m2 = calcSleepPeriods(micro, baseline);
+  assert(m2.periods.length === 0 && m2.confidence === 0, 'micro-doze (<15 min) discarded');
+
+  // Empty input → no periods, conf 0.
+  const ep = calcSleepPeriods([], baseline);
+  assert(ep.periods.length === 0 && ep.confidence === 0, 'no data → no periods + conf 0');
 }
 
 // ── §6 calcSleepRegularity ───────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export { calcCalories } from './calories';
 
 // §5 Sleep
 export { calcSleep } from './sleep';
+// §5b Sleep v2 — multi-period (naps = shorter sleeps). Additive; calcSleep unchanged.
+export { calcSleepPeriods } from './sleep';
 
 // §6 Sleep regularity (SRI)
 export { calcSleepRegularity } from './regularity';

--- a/src/sleep.ts
+++ b/src/sleep.ts
@@ -1,6 +1,9 @@
 // §5 Sleep — Cole-Kripke actigraphy + HR-dip fusion. Tier HIGH (duration/eff),
 // ESTIMATE (stages). One-minute epochs.
-import type { Minute, Baseline, Metric, SleepValue, SleepStages } from './types';
+import type {
+  Minute, Baseline, Metric, SleepValue, SleepStages,
+  SleepPeriod, SleepPeriodsValue,
+} from './types';
 import { isHrUsable, mean, round } from './util';
 
 // Cole-Kripke weights over window [-4..+2].
@@ -197,6 +200,140 @@ export function calcSleep(minutes: Minute[], baseline: Baseline): Metric<SleepVa
     stages,
     stages_beta: true,
     confidence: round(confidence, 4),
+    tier: 'HIGH',
+    inputs_used,
+  };
+}
+
+/**
+ * calcSleepPeriods(minutes, baseline)  —  Sleep v2 (multi-period)
+ *
+ * Same epoch scorer + consolidation as calcSleep, but instead of keeping only the
+ * single longest period we return EVERY consolidated sleep period in the window.
+ * A nap is not a special case — it's just a shorter sleep. Slept once → one
+ * period; napped twice → three periods total; the UI renders one card each.
+ *
+ * Each period carries its own full breakdown (onset/wake/duration/efficiency/
+ * stages) and its own confidence. The longest period is flagged `is_main` purely
+ * as a UI hint; the data treats all periods identically.
+ *
+ * Per-period confidence = input_completeness × clamp(in_bed_min/90, 0, 1) — a ~90
+ * min block reaches full coverage, so a genuine 40-min nap isn't unfairly crushed
+ * the way the 240-min night-coverage of calcSleep would crush it.
+ *
+ * Periods with fewer than MIN_PERIOD_MIN asleep minutes are discarded (micro-dozes
+ * aren't sleep). The top-level Metric.confidence mirrors the main period.
+ */
+export function calcSleepPeriods(minutes: Minute[], baseline: Baseline): Metric<SleepPeriodsValue> {
+  const sorted = [...minutes].sort((a, b) => a.ts - b.ts);
+  const n = sorted.length;
+  const rhr = baseline.resting_hr;
+
+  const empty = (): Metric<SleepPeriodsValue> => ({
+    periods: [],
+    total_asleep_min: 0,
+    main_idx: null,
+    stages_beta: true,
+    confidence: 0,
+    tier: 'HIGH',
+    inputs_used: [],
+  });
+  if (n === 0) return empty();
+
+  // 1. Per-epoch asleep — identical scorer to calcSleep (duplicated here on
+  //    purpose so v1 stays byte-for-byte untouched).
+  const asleep: boolean[] = new Array(n).fill(false);
+  for (let i = 0; i < n; i++) {
+    let s = 0;
+    for (let k = 0; k < CK_W.length; k++) {
+      const off = k - 4;
+      const idx = i + off;
+      if (idx >= 0 && idx < n) s += CK_W[k] * sorted[idx].activity;
+    }
+    s *= 0.001;
+    const m = sorted[i];
+    if (!m.wrist_on) { asleep[i] = false; continue; }
+    let isAsleep = s < 1;
+    if (m.hr_avg > 0) {
+      if (m.hr_avg < 0.95 * rhr) isAsleep = true;
+      else if (m.hr_avg > 1.15 * rhr) isAsleep = false;
+    }
+    asleep[i] = isAsleep;
+  }
+
+  // 2. Collect ALL consolidated periods (same ≤20-min interior-gap rule as the
+  //    main-sleep detector). Each is trimmed to its first/last asleep epoch.
+  const MAX_GAP_MIN = 20;
+  const MAX_SLEEP_MIN = 14 * 60; // same plausibility ceiling, applied per period
+  const MIN_PERIOD_MIN = 15;     // shorter than this isn't a sleep period
+
+  const raw: { start: number; end: number; asleepN: number }[] = [];
+  let pf = -1, pl = -1, pa = 0, gap = 0;
+  const close = () => {
+    if (pf >= 0 && pa > 0) raw.push({ start: pf, end: pl, asleepN: pa });
+    pf = -1; pl = -1; pa = 0; gap = 0;
+  };
+  for (let i = 0; i < n; i++) {
+    if (asleep[i]) { if (pf < 0) pf = i; pl = i; pa++; gap = 0; }
+    else if (pf >= 0) { if (++gap > MAX_GAP_MIN) close(); }
+  }
+  close();
+
+  const periods: SleepPeriod[] = [];
+  for (const p of raw) {
+    let startIdx = p.start;
+    let endIdx = p.end;
+    if (endIdx - startIdx + 1 > MAX_SLEEP_MIN) endIdx = startIdx + MAX_SLEEP_MIN - 1;
+
+    const span = sorted.slice(startIdx, endIdx + 1);
+    const in_bed_min = span.length;
+    let duration_min = 0;
+    for (let i = startIdx; i <= endIdx; i++) if (asleep[i]) duration_min++;
+    if (duration_min < MIN_PERIOD_MIN) continue;
+
+    const efficiency = in_bed_min > 0 ? duration_min / in_bed_min : 0;
+    const sleepEpochs = span.filter((_, i) => asleep[startIdx + i]);
+    const stages = estimateStages(sleepEpochs, rhr);
+
+    const hasHr = span.some((m) => m.wrist_on && m.hr_avg > 0);
+    const hasActivity = span.some((m) => m.activity > 0);
+    const hasTemp = baseline.skin_temp != null;
+    const inputCompleteness = [hasHr, hasActivity, hasTemp].filter(Boolean).length / 3;
+    const coverage = Math.min(1, in_bed_min / 90);
+
+    periods.push({
+      onset_ts: sorted[startIdx].ts,
+      wake_ts: sorted[endIdx].ts,
+      duration_min,
+      in_bed_min,
+      efficiency: round(efficiency, 4),
+      stages,
+      is_main: false,
+      confidence: round(inputCompleteness * coverage, 4),
+    });
+  }
+
+  if (periods.length === 0) return empty();
+
+  // 3. Flag the longest period as the main one (UI hint only).
+  let main_idx = 0;
+  for (let i = 1; i < periods.length; i++) {
+    if (periods[i].duration_min > periods[main_idx].duration_min) main_idx = i;
+  }
+  periods[main_idx].is_main = true;
+
+  const total_asleep_min = periods.reduce((a, p) => a + p.duration_min, 0);
+
+  const inputs_used: string[] = ['activity'];
+  if (sorted.some((m) => m.wrist_on && m.hr_avg > 0)) inputs_used.push('hr_avg');
+  if (baseline.skin_temp != null) inputs_used.push('baseline.skin_temp');
+
+  return {
+    periods,
+    total_asleep_min,
+    main_idx,
+    stages_beta: true,
+    confidence: periods[main_idx].confidence,
     tier: 'HIGH',
     inputs_used,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,27 @@ export interface SleepValue {
   stages_beta: boolean;
 }
 
+// ── Sleep v2 (multi-period) — naps are just shorter sleeps ───────────────────
+/** One consolidated sleep period. Same breakdown as SleepValue, per-period. */
+export interface SleepPeriod {
+  onset_ts: number;
+  wake_ts: number;
+  duration_min: number; // asleep minutes
+  in_bed_min: number;
+  efficiency: number;   // 0..1
+  stages: SleepStages | null; // BETA/ESTIMATE
+  is_main: boolean;     // longest period of the day (UI hint only; data is uniform)
+  confidence: number;   // per-period detection confidence (0..1)
+}
+
+/** All sleep periods detected in a window (one card each in the UI). */
+export interface SleepPeriodsValue {
+  periods: SleepPeriod[];     // chronological
+  total_asleep_min: number;   // sum across periods
+  main_idx: number | null;    // index of the main (longest) period, or null
+  stages_beta: boolean;
+}
+
 export interface SleepRegularityValue {
   sri: number; // 0..100
   onset_std_min: number;


### PR DESCRIPTION
Detect every consolidated sleep period in a window (reusing the Cole-Kripke + HR-dip scorer), each with its own breakdown; longest flagged is_main. Naps are not special-cased — just shorter sleeps. Adds SleepPeriod/SleepPeriodsValue types, index export, and tests. calcSleep (v1) untouched.