### PR TITLE
fix: abstain from sleep detection without a resting-HR baseline

### DIFF
--- a/src/sleep.ts
+++ b/src/sleep.ts
@@ -50,6 +50,10 @@ export function calcSleep(minutes: Minute[], baseline: Baseline): Metric<SleepVa
   if (n === 0) return empty();
 
   const rhr = baseline.resting_hr;
+  // Cole–Kripke + HR-dip fusion is anchored on resting HR; without a real
+  // baseline (null/0 for a brand-new user) the dip comparisons degrade to
+  // garbage (everything reads "awake"). Abstain until we have one.
+  if (rhr == null || rhr <= 0) return empty();
 
   // 1. Cole-Kripke score + HR-dip fusion → boolean asleep per epoch.
   const asleep: boolean[] = new Array(n).fill(false);
@@ -239,6 +243,7 @@ export function calcSleepPeriods(minutes: Minute[], baseline: Baseline): Metric<
     inputs_used: [],
   });
   if (n === 0) return empty();
+  if (rhr == null || rhr <= 0) return empty(); // need a resting-HR baseline (see calcSleep)
 
   // 1. Per-epoch asleep — identical scorer to calcSleep (duplicated here on
   //    purpose so v1 stays byte-for-byte untouched).


### PR DESCRIPTION
calcSleep/calcSleepPeriods produced garbage (all-awake) when baseline.resting_hr was null/0 (new user) because `0.95 * null = 0`. Now return empty until a baseline exists. Bundled into the backend deploy (version 5ec30fe7) via the file: dependency. 151/151 tests pass.