### PR TITLE
feat: sleep/wake ensemble (wake.ts) — pluggable voters

### DIFF
--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -21,6 +21,7 @@ import { calcIllness } from '../illness';
 import { timeDomainHrv, freqDomainHrv, baevskyStressIndex, cleanRr } from '../hrv';
 import { pedometer, calcSteps, STEP_PARAMS } from '../steps';
 import { resolveMaxHr } from '../util';
+import { calcCircadian } from '../circadian';
 
 const baseline: Baseline = {
   resting_hr: 50,
@@ -691,6 +692,34 @@ console.log('--- §Steps pedometer ---');
   approx(calcSteps([walk]), Math.round(raw * STEP_PARAMS.GAIN), 0.001,
     'calcSteps applies the ×GAIN calibration to the summed raw count');
   assert(STEP_PARAMS.GAIN === 1.11, 'locked calibration gain = 1.11');
+}
+
+// ── §Circadian — CircaCP cosinor + bounded change-point ──────────────────────
+console.log('--- §Circadian calcCircadian ---');
+{
+  // 2 days of 1-min HR: asleep (hr≈55) hours [1,8), awake (hr≈80) otherwise.
+  // Onset ≈ 01:00, wake ≈ 08:00 each day; sharp transitions.
+  const mins: Minute[] = [];
+  for (let i = 0; i < 2 * 1440; i++) {
+    const ts = i * 60;
+    const hod = Math.floor(ts / 3600) % 24;
+    const asleep = hod >= 1 && hod < 8;
+    const hr = (asleep ? 55 : 80) + (i % 5) - 2; // tiny deterministic jitter
+    mins.push(min(ts, hr));
+  }
+  const c = calcCircadian(mins);
+  assert(c.amplitude !== null && c.amplitude > 5, `circadian amplitude detected (got ${c.amplitude})`);
+  // day-2 onset ≈ 90000s (25:00 → 01:00 day 2), wake ≈ 115200s (32:00 → 08:00 day 2)
+  assert(c.onset_ts !== null && Math.abs(c.onset_ts - 90000) <= 1800, `onset ≈ 01:00 day2 (got ${c.onset_ts})`);
+  assert(c.wake_ts !== null && Math.abs(c.wake_ts - 115200) <= 1800, `wake ≈ 08:00 day2 (got ${c.wake_ts})`);
+  assert(c.settled === true, 'completed night marked settled');
+  assert(c.confidence > 0.5, `confidence high on clean rhythm (got ${c.confidence})`);
+
+  // flat HR (no rhythm) → abstain
+  const flat: Minute[] = [];
+  for (let i = 0; i < 2 * 1440; i++) flat.push(min(i * 60, 70));
+  const cf = calcCircadian(flat);
+  assert(cf.onset_ts === null && cf.confidence < 0.3, 'flat HR → abstains (no fabricated boundary)');
 }
 
 summary('analytics');

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -22,6 +22,7 @@ import { timeDomainHrv, freqDomainHrv, baevskyStressIndex, cleanRr } from '../hr
 import { pedometer, calcSteps, STEP_PARAMS } from '../steps';
 import { resolveMaxHr } from '../util';
 import { calcCircadian } from '../circadian';
+import { detectWakeState, peekRecentState } from '../wake';
 
 const baseline: Baseline = {
   resting_hr: 50,
@@ -720,6 +721,34 @@ console.log('--- §Circadian calcCircadian ---');
   for (let i = 0; i < 2 * 1440; i++) flat.push(min(i * 60, 70));
   const cf = calcCircadian(flat);
   assert(cf.onset_ts === null && cf.confidence < 0.3, 'flat HR → abstains (no fabricated boundary)');
+}
+
+// ── detectWakeState (sleep/wake ensemble) ─────────────────────────────────────
+{
+  const bl: Baseline = { resting_hr: 50, max_hr: 190, sleep_need_min: 480 };
+  // 8h sleep (low HR, still) then N min awake (elevated HR, moving + steps).
+  const build = (awakeMin: number): Minute[] => {
+    const out: Minute[] = [];
+    let t = 0;
+    for (let i = 0; i < 480; i++, t += 60) out.push(min(t, 50, 0.01, { wrist_on: true }));
+    for (let i = 0; i < awakeMin; i++, t += 60) out.push(min(t, 72, 0.4, { steps: 20, wrist_on: true }));
+    return out;
+  };
+
+  const woke = detectWakeState({ minutes: build(15), baseline: bl });
+  assert(woke.state === 'awake', `ensemble: state awake after waking (got ${woke.state})`);
+  assert(woke.wake_ts != null && Math.abs(woke.wake_ts - 480 * 60) <= 180, `ensemble: wake_ts ≈ sleep→wake boundary ±3min (got ${woke.wake_ts})`);
+  assert(woke.awake_min >= 12 && woke.awake_min <= 19, `ensemble: sustained awake ~15 min ±detector fuzz (got ${woke.awake_min})`);
+  assert(woke.asleep_min >= 90, `ensemble: main sleep ≥90 min (got ${woke.asleep_min})`);
+
+  const tooSoon = detectWakeState({ minutes: build(5), baseline: bl });
+  assert(tooSoon.wake_ts === null, 'ensemble: <10 min awake → no premature wake fire');
+
+  const stillAsleep = detectWakeState({ minutes: build(0), baseline: bl });
+  assert(stillAsleep.state === 'asleep' && stillAsleep.wake_ts === null, 'ensemble: mid-sleep → asleep, no wake_ts');
+
+  const movingTail = [min(0, 72, 0.4, { steps: 20, wrist_on: true }), min(60, 73, 0.5, { steps: 25, wrist_on: true }), min(120, 71, 0.3, { steps: 10, wrist_on: true })];
+  assert(peekRecentState(movingTail, bl) === 'awake', 'peek: moving + HR up → awake');
 }
 
 summary('analytics');

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -25,6 +25,7 @@ import { resolveMaxHr } from '../util';
 import { calcCircadian, stageSleep } from '../circadian';
 import { detectSleepCycles } from '../cycles';
 import { detectWakeState, peekRecentState } from '../wake';
+import { calcCycle } from '../cycle';
 
 const baseline: Baseline = {
   resting_hr: 50,
@@ -874,6 +875,44 @@ console.log('--- §Circadian calcCircadian ---');
   // → below the ≥2 bar → stays asleep rather than guess.
   const noRr = detectWakeState({ minutes, baseline: bl });
   assert(noRr.wake_ts === null, `no-RR + no-motion quiet wake cannot be confirmed (honest) (got ${noRr.wake_ts})`);
+}
+
+// ── menstrual cycle (log-anchored calendar method) ───────────────────────────
+{
+  // No logs → empty/abstain.
+  const none = calcCycle([], '2026-06-20');
+  assert(none.confidence === 0 && none.phase === 'unknown' && none.predicted_next === null,
+    'cycle: no logs → abstain');
+
+  // Three regular 28-day starts → median 28, prediction = last + 28.
+  const starts = ['2026-04-04', '2026-05-02', '2026-05-30'];
+  const c = calcCycle(starts, '2026-06-06'); // day 8 of the cycle that began 05-30
+  assert(c.mean_length === 28, `cycle: median length 28 (got ${c.mean_length})`);
+  assert(c.length_history.length === 2, `cycle: 2 observed lengths (got ${c.length_history.length})`);
+  assert(c.cycle_day === 8, `cycle: cycle day 8 (got ${c.cycle_day})`);
+  assert(c.predicted_next === '2026-06-27', `cycle: next period 06-27 (got ${c.predicted_next})`);
+  assert(c.ovulation_est === '2026-06-13', `cycle: ovulation = next−14 (got ${c.ovulation_est})`);
+  assert(c.fertile_start === '2026-06-08' && c.fertile_end === '2026-06-14',
+    `cycle: fertile window ov−5..ov+1 (got ${c.fertile_start}..${c.fertile_end})`);
+  assert(c.phase === 'follicular', `cycle: day 8 pre-ovulation → follicular (got ${c.phase})`);
+  assert(c.confidence > 0.5, `cycle: confidence grows with cycles (got ${c.confidence})`);
+
+  // Menstruation window (day ≤ 5).
+  const m = calcCycle(starts, '2026-05-31'); // day 2
+  assert(m.phase === 'menstruation', `cycle: day 2 → menstruation (got ${m.phase})`);
+
+  // Luteal: after the fertile window, before next period.
+  const l = calcCycle(starts, '2026-06-20'); // day 22
+  assert(l.phase === 'luteal', `cycle: day 22 → luteal (got ${l.phase})`);
+
+  // Very overdue → prediction unreliable, abstain on phase + low confidence.
+  const od = calcCycle(starts, '2026-07-25'); // ~56 days since last start
+  assert(od.phase === 'unknown' && od.confidence <= 0.2, `cycle: very overdue → unknown/low conf (got ${od.phase}/${od.confidence})`);
+
+  // Single log → 28-day default, low-but-nonzero confidence.
+  const one = calcCycle(['2026-06-10'], '2026-06-15');
+  assert(one.mean_length === null && one.predicted_next === '2026-07-08' && one.confidence > 0,
+    `cycle: single log uses 28d default (got ${one.predicted_next}/${one.confidence})`);
 }
 
 summary('analytics');

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -801,4 +801,30 @@ console.log('--- §Circadian calcCircadian ---');
   assert(peekRecentState(movingTail, bl) === 'awake', 'peek: moving + HR up → awake');
 }
 
+// ── regression: QUIET sedentary wake (HR up, NO motion, RR present) must fire ──
+// The real-world bug: a user awake but still (on the phone in bed) has elevated HR
+// and RR but ~zero motion. The OLD flat 2-of-3 majority let the two motion voters
+// (blind to quiet wake) outvote cardiac → "asleep" → close never fired → no recovery.
+// The ≥2 consensus must let the autonomic pair (cardiac + hrvArousal) carry the wake.
+{
+  const bl: Baseline = { resting_hr: 55, max_hr: 190, sleep_need_min: 480 };
+  const minutes: Minute[] = [];
+  const rrByMin = new Map<number, number[]>();
+  let t = 0;
+  const rr = (meanMs: number, sd: number, n = 40) => Array.from({ length: n }, (_, j) => meanMs + (j % 2 ? sd : -sd));
+  for (let i = 0; i < 480; i++, t += 60) { minutes.push(min(t, 52, 0.01, { wrist_on: true })); rrByMin.set(t, rr(1150, 12)); } // sleep: low HR, still, low RR-SD
+  for (let i = 0; i < 30; i++, t += 60) { minutes.push(min(t, 74, 0.01, { wrist_on: true })); rrByMin.set(t, rr(810, 60)); }   // QUIET wake: HR up, NO motion, high RR-SD
+
+  const ws = detectWakeState({ minutes, baseline: bl, rrByMin });
+  assert(ws.state === 'awake', `quiet sedentary wake detected without motion (got ${ws.state})`);
+  assert(ws.wake_ts != null && Math.abs(ws.wake_ts - 480 * 60) <= 180, `quiet wake_ts at the boundary (got ${ws.wake_ts})`);
+  assert(ws.asleep_min >= 90, `main sleep preserved (got ${ws.asleep_min})`);
+  assert(ws.votes.cardiac === 'awake' && ws.votes.hrvArousal === 'awake', 'autonomic pair both vote awake at wake');
+
+  // Honest degradation: same still-but-awake tail with NO RR → only 1 signal (cardiac)
+  // → below the ≥2 bar → stays asleep rather than guess.
+  const noRr = detectWakeState({ minutes, baseline: bl });
+  assert(noRr.wake_ts === null, `no-RR + no-motion quiet wake cannot be confirmed (honest) (got ${noRr.wake_ts})`);
+}
+
 summary('analytics');

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -21,7 +21,7 @@ import { calcIllness } from '../illness';
 import { timeDomainHrv, freqDomainHrv, baevskyStressIndex, cleanRr } from '../hrv';
 import { pedometer, calcSteps, STEP_PARAMS } from '../steps';
 import { resolveMaxHr } from '../util';
-import { calcCircadian } from '../circadian';
+import { calcCircadian, stageSleep } from '../circadian';
 import { detectWakeState, peekRecentState } from '../wake';
 
 const baseline: Baseline = {
@@ -650,6 +650,56 @@ console.log('--- regression: sleep stage proportions ---');
   assert(st.rem_min / tot < 0.40, `REM is a minority, not dominant (got ${(100*st.rem_min/tot).toFixed(0)}%)`);
   assert(st.deep_min / tot > 0.05, `some deep sleep detected (got ${(100*st.deep_min/tot).toFixed(0)}%)`);
   assert(st.light_min >= st.rem_min, `light ≥ REM (light ${st.light_min} vs REM ${st.rem_min})`);
+}
+
+// ── regression: stageSleep detects REM from RR variability on a flat-HR night ──
+console.log('--- regression: RR-driven REM staging ---');
+{
+  // A calm night where HR is nearly flat (≈60 bpm) so HR LEVEL alone CANNOT separate
+  // REM from light (the real bug: REM read 0%). REM is encoded the physiological way —
+  // parasympathetic withdrawal → REDUCED beat-to-beat variability (low RMSSD), with HR
+  // only mildly above light. Deep = high RMSSD + lowest HR. stageSleep must use the RR
+  // autonomic axis to recover a physiological REM share (15–25%), not 0.
+  const ONSET = 0, WAKE = 280 * 60;
+  // Build a minute's RR stream with a target RMSSD: alternate ±d around the mean RR so
+  // successive |Δ| ≈ 2d ⇒ RMSSD ≈ 2d (kept < 200 ms so cleanRr doesn't drop beats).
+  const rrFor = (hr: number, rmssdTarget: number): number[] => {
+    const meanRr = Math.round(60000 / hr);
+    const d = Math.min(95, Math.round(rmssdTarget / 2));
+    const out: number[] = [];
+    for (let j = 0; j < 48; j++) out.push(meanRr + (j % 2 === 0 ? d : -d));
+    return out;
+  };
+  type SM = { ts: number; hr_avg: number; rr?: number[] };
+  const night: SM[] = [];
+  const push = (a: number, b: number, hr: number, rmssd: number) => {
+    for (let i = a; i < b; i++) night.push({ ts: i * 60, hr_avg: hr, rr: rrFor(hr, rmssd) });
+  };
+  push(0, 30, 60, 50);     // light  (medium variability)
+  push(30, 95, 56, 90);    // deep   (high RMSSD, lowest HR)
+  push(95, 150, 60, 50);   // light
+  push(150, 215, 64, 16);  // REM    (low RMSSD, mildly elevated HR)
+  push(215, 280, 60, 50);  // light
+  const ss = stageSleep(night, ONSET, WAKE, /*mesor*/ 90);
+  const tot = ss.light_min + ss.deep_min + ss.rem_min;
+  assert(tot > 0, 'RR-staged night produced stages');
+  const remPct = (100 * ss.rem_min) / tot, deepPct = (100 * ss.deep_min) / tot;
+  assert(remPct >= 12 && remPct <= 35, `REM recovered from RR, physiological share (got ${remPct.toFixed(0)}%)`);
+  assert(deepPct >= 8, `deep detected from high-RMSSD block (got ${deepPct.toFixed(0)}%)`);
+  assert(ss.light_min >= ss.rem_min, 'light remains dominant');
+  // 0 short(<20 min) awake flaps in the hypnogram.
+  let flaps = 0;
+  for (let i = 0; i < ss.hypnogram.length;) {
+    let j = i; while (j < ss.hypnogram.length && ss.hypnogram[j].stage === ss.hypnogram[i].stage) j++;
+    if (ss.hypnogram[i].stage === 'awake' && (j - i) < 20) flaps++;
+    i = j;
+  }
+  assert(flaps === 0, `no short awake flaps (got ${flaps})`);
+  // Without RR, the SAME flat-HR night cannot resolve REM → graceful HR-only fallback
+  // (must not throw, must not fabricate a REM-dominated night).
+  const noRr = night.map((m) => ({ ts: m.ts, hr_avg: m.hr_avg }));
+  const fb = stageSleep(noRr, ONSET, WAKE, 90);
+  assert((fb.light_min + fb.deep_min + fb.rem_min) > 0, 'HR-only fallback still stages');
 }
 
 // ── regression: resolveMaxHr doesn't promote a quiet within-day peak ──────────

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -15,6 +15,7 @@ import { calcLoad, calcFitnessTrend } from '../trends';
 import { calcAnomaly } from '../readiness';
 import { calcBaselines } from '../baselines';
 import { calcStress } from '../stress';
+import { calcSpo2Index } from '../spo2';
 import { calcSleepStress } from '../arousal';
 import { calcNocturnalHeart } from '../nocturnal';
 import { calcIllness } from '../illness';
@@ -532,6 +533,28 @@ console.log('--- §12 calcStress (HRV) ---');
   assert((hi.score ?? 0) >= (withBase.score ?? 0), 'higher SI vs baseline → higher stress');
   // determinism
   assert(JSON.stringify(calcStress(rr, baseSI)) === JSON.stringify(calcStress(rr, baseSI)), 'stress deterministic');
+}
+
+// ── §SpO₂ relative index (red/IR ratio) ───────────────────────────────────────
+console.log('--- §calcSpo2Index ---');
+{
+  // Too few minutes → null, conf 0.
+  assert(calcSpo2Index([0.85, 0.86, 0.85], 0.85).index === null, 'spo2: <30 min → null');
+  assert(calcSpo2Index([0.85, 0.86], 0.85).confidence === 0, 'spo2: too few → conf 0');
+  // No baseline yet → seed night_ratio, null index.
+  const stable = Array.from({ length: 200 }, () => 0.850);
+  const seed = calcSpo2Index(stable, null);
+  assert(seed.index === null, 'spo2: no baseline → null index');
+  approx(seed.night_ratio!, 0.85, 0.001, 'spo2: no baseline → seed night_ratio');
+  // Stable clean night vs baseline → high confidence; lower ratio than baseline → positive index.
+  const better = calcSpo2Index(Array.from({ length: 200 }, () => 0.840), 0.850);
+  assert(better.index !== null && better.index > 0, 'spo2: lower ratio than baseline → positive index');
+  assert(better.confidence > 0.8, 'spo2: stable + plenty of samples → high confidence');
+  // Noisy night (high intra-night CV) → low confidence even with a baseline.
+  const noisy = calcSpo2Index(Array.from({ length: 200 }, (_, i) => 0.85 + (i % 2 ? 0.08 : -0.08)), 0.850);
+  assert(noisy.confidence < 0.3, 'spo2: high intra-night CV → low confidence');
+  // Plausibility gate drops garbage ratios.
+  assert(calcSpo2Index(Array.from({ length: 200 }, () => 3.0), 0.85).index === null, 'spo2: implausible ratios → null');
 }
 
 // ── §sleep-stress / nocturnal arousal ─────────────────────────────────────────

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -23,6 +23,7 @@ import { timeDomainHrv, freqDomainHrv, baevskyStressIndex, cleanRr } from '../hr
 import { pedometer, calcSteps, STEP_PARAMS } from '../steps';
 import { resolveMaxHr } from '../util';
 import { calcCircadian, stageSleep } from '../circadian';
+import { detectSleepCycles } from '../cycles';
 import { detectWakeState, peekRecentState } from '../wake';
 
 const baseline: Baseline = {
@@ -723,6 +724,31 @@ console.log('--- regression: RR-driven REM staging ---');
   const noRr = night.map((m) => ({ ts: m.ts, hr_avg: m.hr_avg }));
   const fb = stageSleep(noRr, ONSET, WAKE, 90);
   assert((fb.light_min + fb.deep_min + fb.rem_min) > 0, 'HR-only fallback still stages');
+}
+
+// ── §Sleep cycles (fractal-cycle method on HRV) ───────────────────────────────
+console.log('--- §detectSleepCycles ---');
+{
+  // RMSSD oscillating with a ~80-min ultradian period over a 320-min night → the
+  // findpeaks(20min, 0.9z) detector should recover ~4 peaks ⇒ ~3 cycles near 80 min.
+  // RR is built so each minute's RMSSD ≈ target: alternate ±d ⇒ RMSSD ≈ 2d.
+  const rrFor = (rmssd: number): number[] => {
+    const d = Math.max(2, Math.round(rmssd / 2));
+    return Array.from({ length: 40 }, (_, j) => 900 + (j % 2 ? d : -d));
+  };
+  const mins: { ts: number; rr: number[] }[] = [];
+  for (let i = 0; i < 320; i++) {
+    const rmssd = 50 + 30 * Math.sin((2 * Math.PI * i) / 80); // ~80-min cycle
+    mins.push({ ts: i * 60, rr: rrFor(rmssd) });
+  }
+  const c = detectSleepCycles(mins, 0, 319 * 60);
+  assert(c.n >= 2 && c.n <= 6, `cycles: ~3-4 ultradian cycles found (got ${c.n})`);
+  assert(c.mean_duration_min != null && c.mean_duration_min >= 55 && c.mean_duration_min <= 110,
+    `cycles: mean duration near the ~80-min period (got ${c.mean_duration_min})`);
+  assert(c.series.length > 0, 'cycles: emits a z-series for plotting');
+  // No RR → abstain cleanly (no fabricated cycles).
+  const noRr = detectSleepCycles(Array.from({ length: 200 }, (_, i) => ({ ts: i * 60 })), 0, 199 * 60);
+  assert(noRr.n === 0 && noRr.cycles.length === 0, 'cycles: no RR → abstains');
 }
 
 // ── regression: resolveMaxHr doesn't promote a quiet within-day peak ──────────

--- a/src/circadian.ts
+++ b/src/circadian.ts
@@ -122,6 +122,30 @@ function changePoint(pts: Pt[], want: 'drop' | 'rise'): { ts: number; before: nu
   return { ts: pts[best.tau].t, before: best.ml, after: best.mr };
 }
 
+/**
+ * Wake = the START of the LAST sustained HR elevation (≥ `threshold` for ≥ `minRunMin`
+ * minutes) in the window. A single change-point picks the most prominent mean-shift,
+ * which for a night with REM/arousal bumps lands mid-sleep, not at the morning rise —
+ * so we instead take the final sustained climb above the cosinor mesor (the awakening
+ * that doesn't come back down). null if HR never sustains above threshold (still asleep).
+ */
+function sustainedWake(pts: Pt[], threshold: number, minRunMin: number): number | null {
+  if (pts.length < 10) return null;
+  const ys = smooth(pts.map((p) => p.y), 5);
+  let wakeIdx = -1;
+  let i = 0;
+  while (i < ys.length) {
+    if (ys[i] >= threshold) {
+      let j = i;
+      while (j < ys.length && ys[j] >= threshold) j++;
+      const runMin = (pts[j - 1].t - pts[i].t) / 60;
+      if (runMin >= minRunMin) wakeIdx = i; // keep the LAST qualifying run
+      i = j;
+    } else i++;
+  }
+  return wakeIdx >= 0 ? pts[wakeIdx].t : null;
+}
+
 export interface CircadianOpts {
   now?: number;       // unix s "now" (default = latest minute ts); for determinism
   settleSec?: number; // a wake older than this = night complete (default 600s)
@@ -161,20 +185,21 @@ export function calcCircadian(minutes: Minute[], opts: CircadianOpts = {}): Metr
   const acroBase = fit.phi / W;
   const nearest = (base: number, ref: number) => base + Math.round((ref - base) / DAY) * DAY;
 
-  // Pick the cycle: target anchor, else the most-recent bathyphase whose +8h wake
-  // window has settled (so we close completed nights, not the one in progress).
-  const anchor = opts.anchorTs ?? now - settle;
-  let bath = nearest(bathBase, anchor);
-  // If that cycle's wake window hasn't settled yet, step back one cycle.
-  if (bath + 8 * 3600 > now - settle) bath -= DAY;
+  // Pick the cycle: the most-recent bathyphase IN THE PAST. The wake is found within
+  // [bath, bath+8h] clipped to available data, and `settled` (wake older than the
+  // settle window) decides whether the night is complete. We deliberately do NOT
+  // require bath+8h to be in the past — that wrongly stepped back a whole night for
+  // an early riser checking soon after waking (the "previous night / short sleep" bug).
+  let bath = nearest(bathBase, opts.anchorTs ?? now);
+  if (bath > now - 3600) bath -= DAY;   // bathyphase must be ~in the past
   const acro = nearest(acroBase, now);
 
   const inWin = (lo: number, hi: number) => usable.filter((p) => p.t >= lo && p.t <= hi);
   const onset = changePoint(inWin(bath - 8 * 3600, bath), 'drop');
-  const wake = changePoint(inWin(bath, bath + 8 * 3600), 'rise');
+  // Wake = final sustained rise above the cosinor mesor (robust to REM/arousal bumps).
+  const wake_ts = sustainedWake(inWin(bath, bath + 8 * 3600), fit.mesor, 12);
 
   const onset_ts = onset ? onset.ts : null;
-  const wake_ts = wake ? wake.ts : null;
   const in_bed_min = onset_ts != null && wake_ts != null ? Math.round((wake_ts - onset_ts) / 60) : 0;
   const settled = wake_ts != null && wake_ts <= now - settle;
 

--- a/src/circadian.ts
+++ b/src/circadian.ts
@@ -13,7 +13,7 @@
 // onset/wake boundary of the most-recent completed cycle. In-sleep staging,
 // efficiency and naps stay with calcSleep / calcSleepPeriods over that window.
 import type { Minute, Metric, CircadianValue } from './types';
-import { isHrUsable, clamp, round } from './util';
+import { isHrUsable, clamp, round, percentile } from './util';
 
 const DAY = 86400;
 const W = (2 * Math.PI) / DAY; // circadian angular frequency (rad/sec)
@@ -89,12 +89,12 @@ function smooth(ys: number[], k: number): number[] {
 }
 
 /**
- * Single mean-shift change-point within a bounded window, constrained to a
- * direction ('drop' = onset, HR falls; 'rise' = wake, HR climbs). Maximises the
- * SSE reduction of a 2-segment split (binary-segmentation cost). null if the
- * window is too thin or no shift of the wanted sign exists.
+ * Single mean-shift change-point in a window, constrained to a direction ('drop' =
+ * onset, HR falls). Maximises the SSE reduction of a 2-segment split — i.e. the
+ * STRONGEST drop, which for the pre-bathyphase window is the evening→sleep onset
+ * (bigger than any quiet-evening dip). null if the window is too thin.
  */
-function changePoint(pts: Pt[], want: 'drop' | 'rise'): { ts: number; before: number; after: number } | null {
+function changePoint(pts: Pt[], want: 'drop' | 'rise'): number | null {
   const MIN = 15;
   if (pts.length < 2 * MIN) return null;
   const ys = smooth(pts.map((p) => p.y), 5);
@@ -108,42 +108,90 @@ function changePoint(pts: Pt[], want: 'drop' | 'rise'): { ts: number; before: nu
     return (pre2[b] - pre2[a]) - (sum * sum) / cnt;
   };
   const total = sse(0, n);
-  let best: { gain: number; tau: number; ml: number; mr: number } | null = null;
+  let best: { gain: number; tau: number } | null = null;
   for (let tau = MIN; tau < n - MIN; tau++) {
-    const ml = pre[tau] / tau;
-    const mr = (pre[n] - pre[tau]) / (n - tau);
-    const d = mr - ml; // +ve = rise
+    const d = (pre[n] - pre[tau]) / (n - tau) - pre[tau] / tau; // +ve = rise
     if (want === 'rise' && d <= 0) continue;
     if (want === 'drop' && d >= 0) continue;
     const gain = total - (sse(0, tau) + sse(tau, n));
-    if (!best || gain > best.gain) best = { gain, tau, ml, mr };
+    if (!best || gain > best.gain) best = { gain, tau };
   }
-  if (!best) return null;
-  return { ts: pts[best.tau].t, before: best.ml, after: best.mr };
+  return best ? pts[best.tau].t : null;
 }
 
 /**
- * Wake = the START of the LAST sustained HR elevation (≥ `threshold` for ≥ `minRunMin`
- * minutes) in the window. A single change-point picks the most prominent mean-shift,
- * which for a night with REM/arousal bumps lands mid-sleep, not at the morning rise —
- * so we instead take the final sustained climb above the cosinor mesor (the awakening
- * that doesn't come back down). null if HR never sustains above threshold (still asleep).
+ * Main sleep period. ONSET = the strongest HR drop in [bath−8h, bath] (the
+ * evening→sleep fall; robust to quiet sedentary evenings that a below-mesor run
+ * would wrongly absorb). WAKE = the end of the consolidated below-MESOR run
+ * extending forward from the bathyphase, bridging interior >mesor bumps ≤ BRIDGE
+ * min (REM/arousal) and ending at the morning rise that persists (daytime). Mesor
+ * is the cosinor midline — sleep below, wake above — so it doesn't cut through
+ * high-sleeping-HR users' light sleep. Returns onset/wake, or null.
  */
-function sustainedWake(pts: Pt[], threshold: number, minRunMin: number): number | null {
-  if (pts.length < 10) return null;
+function mainSleepPeriod(pts: Pt[], bath: number, mesor: number): { onset: number; wake: number } | null {
+  const n = pts.length;
+  if (n < 30) return null;
   const ys = smooth(pts.map((p) => p.y), 5);
-  let wakeIdx = -1;
-  let i = 0;
+  const asleep = ys.map((v) => v < mesor);
+  // anchor = index nearest the bathyphase
+  let a = 0;
+  for (let i = 1; i < n; i++) if (Math.abs(pts[i].t - bath) < Math.abs(pts[a].t - bath)) a = i;
+  const BRIDGE = 60 * 60;
+  // wake: walk forward from anchor, bridging >mesor gaps ≤ BRIDGE; stop at a long one.
+  let end = a;
+  for (let i = a + 1; i < n;) {
+    if (asleep[i]) { end = i; i++; continue; }
+    let k = i; while (k < n && !asleep[k]) k++;
+    if (pts[(k < n ? k : n) - 1].t - pts[i].t > BRIDGE) break;
+    i = k;
+  }
+  // onset: strongest evening→sleep drop; fall back to the below-mesor run start.
+  let start = a;
+  for (let i = a - 1; i >= 0;) {
+    if (asleep[i]) { start = i; i--; continue; }
+    let k = i; while (k >= 0 && !asleep[k]) k--;
+    if (pts[i].t - pts[k + 1].t > BRIDGE) break;
+    i = k;
+  }
+  const onsetCp = changePoint(pts.filter((p) => p.t >= bath - 8 * 3600 && p.t <= bath), 'drop');
+  const onset = onsetCp != null && onsetCp >= pts[start].t ? onsetCp : pts[start].t;
+  return { onset, wake: pts[end].t };
+}
+
+/**
+ * Sleep efficiency / WASO over a fixed [onset, wake] window, HR-only (ESTIMATE).
+ * WASO = minutes in SUSTAINED elevations (≥15 min) above a threshold set partway
+ * between the night's sleeping floor (20th-pctile HR) and the cosinor mesor — so
+ * brief REM/arousal bumps don't count, but prolonged wakefulness does. asleep =
+ * worn − WASO; efficiency = asleep / in-bed. Honest middle ground for HR-only: it
+ * neither pins efficiency at 1.0 (mesor-only) nor calls every REM bump "awake".
+ */
+export function sleepEfficiency(
+  minutes: { ts: number; hr_avg: number }[], onset: number, wake: number, mesor: number,
+): { in_bed_min: number; asleep_min: number; efficiency: number; waso_min: number } {
+  const inBed = Math.max(1, Math.round((wake - onset) / 60));
+  const win = minutes.filter((m) => m.ts >= onset && m.ts <= wake && m.hr_avg > 0)
+    .sort((a, b) => a.ts - b.ts);
+  const worn = win.length;
+  if (worn < 5) return { in_bed_min: inBed, asleep_min: worn, efficiency: clamp(worn / inBed, 0, 1), waso_min: 0 };
+  const hrs = win.map((m) => m.hr_avg);
+  // WASO threshold sits HIGH — 0.70 of the way from the sleeping floor to the mesor —
+  // so only clear, near-wake elevations count as awake, not normal light/REM sleep HR
+  // (which for high-sleeping-HR users sits well above the floor). Sustained ≥20 min.
+  const floor = percentile(hrs, 10) ?? Math.min(...hrs);
+  const threshold = Math.max(floor + 10, floor + 0.70 * (mesor - floor));
+  const ys = smooth(hrs, 5);
+  let waso = 0, i = 0;
   while (i < ys.length) {
     if (ys[i] >= threshold) {
       let j = i;
       while (j < ys.length && ys[j] >= threshold) j++;
-      const runMin = (pts[j - 1].t - pts[i].t) / 60;
-      if (runMin >= minRunMin) wakeIdx = i; // keep the LAST qualifying run
+      if ((win[j - 1].ts - win[i].ts) / 60 >= 20) waso += j - i; // sustained → count as awake
       i = j;
     } else i++;
   }
-  return wakeIdx >= 0 ? pts[wakeIdx].t : null;
+  const asleep = Math.max(0, worn - waso);
+  return { in_bed_min: inBed, asleep_min: asleep, efficiency: clamp(asleep / inBed, 0, 1), waso_min: waso };
 }
 
 export interface CircadianOpts {
@@ -178,6 +226,8 @@ export function calcCircadian(minutes: Minute[], opts: CircadianOpts = {}): Metr
   const now = opts.now ?? usable[usable.length - 1].t;
   const fit = fitCosinor(usable);
   if (!fit) return empty();
+  // No detectable circadian rhythm (flat HR) → abstain, never fabricate a boundary.
+  if (fit.amp < 3) return empty();
 
   // bathyphase (HR trough): amp·cos(ωt − φ) minimal → ωt − φ = π.
   const bathBase = (fit.phi + Math.PI) / W;
@@ -195,11 +245,10 @@ export function calcCircadian(minutes: Minute[], opts: CircadianOpts = {}): Metr
   const acro = nearest(acroBase, now);
 
   const inWin = (lo: number, hi: number) => usable.filter((p) => p.t >= lo && p.t <= hi);
-  const onset = changePoint(inWin(bath - 8 * 3600, bath), 'drop');
-  // Wake = final sustained rise above the cosinor mesor (robust to REM/arousal bumps).
-  const wake_ts = sustainedWake(inWin(bath, bath + 8 * 3600), fit.mesor, 12);
-
-  const onset_ts = onset ? onset.ts : null;
+  // Consolidated main-sleep period around the bathyphase (handles REM bumps + daytime).
+  const period = mainSleepPeriod(inWin(bath - 8 * 3600, bath + 10 * 3600), bath, fit.mesor);
+  const onset_ts = period ? period.onset : null;
+  const wake_ts = period ? period.wake : null;
   const in_bed_min = onset_ts != null && wake_ts != null ? Math.round((wake_ts - onset_ts) / 60) : 0;
   const settled = wake_ts != null && wake_ts <= now - settle;
 

--- a/src/circadian.ts
+++ b/src/circadian.ts
@@ -14,6 +14,7 @@
 // efficiency and naps stay with calcSleep / calcSleepPeriods over that window.
 import type { Minute, Metric, CircadianValue } from './types';
 import { isHrUsable, clamp, round, percentile } from './util';
+import { cleanRr } from './hrv';
 
 const DAY = 86400;
 const W = (2 * Math.PI) / DAY; // circadian angular frequency (rad/sec)
@@ -74,6 +75,23 @@ function solve3(A: number[][], b: number[]): [number, number, number] | null {
     }
   }
   return [m[0][3], m[1][3], m[2][3]];
+}
+
+/** Per-minute RMSSD (ms) from a (raw) RR stream; null if too few beats to be
+ *  meaningful. Cleans physiological + ectopic artifacts first (shared `cleanRr`). */
+function minuteRmssd(rr: number[] | undefined): number | null {
+  if (!rr || rr.length < 12) return null;
+  const c = cleanRr(rr);
+  if (c.length < 10) return null;
+  let s = 0;
+  for (let i = 1; i < c.length; i++) { const d = c[i] - c[i - 1]; s += d * d; }
+  return Math.sqrt(s / (c.length - 1));
+}
+
+/** Median of finite values; null if none. */
+function medOf(xs: (number | null)[]): number | null {
+  const a = xs.filter((x): x is number => x != null && Number.isFinite(x)).sort((p, q) => p - q);
+  return a.length ? a[a.length >> 1] : null;
 }
 
 /** Median filter (±k) to denoise HR before change-point search. */
@@ -165,21 +183,29 @@ export interface SleepStaging {
 }
 
 /**
- * The ONE sleep stager (HR-only, ESTIMATE/beta). Classifies every minute in
- * [onset, wake] into awake / light / deep / rem off thresholds anchored between the
- * night's sleeping floor (10th-pctile HR) and the cosinor mesor, then returns BOTH
- * the per-minute hypnogram AND the reconciled totals — so the graph and the stage
- * breakdown can never disagree (the previous bug: two different classifiers).
+ * The ONE sleep stager (ESTIMATE/beta). Classifies every minute in [onset, wake]
+ * into awake / light / deep / rem, then returns BOTH the per-minute hypnogram AND the
+ * reconciled totals — so the graph and the stage breakdown can never disagree (the
+ * previous bug: two different classifiers).
  *
- *   awake = SUSTAINED (≥20 min) HR ≥ floor+0.70·(mesor−floor), or off-wrist — only
- *           clear near-wake elevations, never normal light/REM HR.
- *   deep  = HR < floor+0.20·(mesor−floor)         (lowest)
- *   rem   = floor+0.45·(mesor−floor) ≤ HR < awake (elevated but asleep)
- *   light = everything else.
+ * TWO AXES:
+ *   • HR LEVEL — sets WAKE (sustained ≥20 min elevation, or off-wrist) and the
+ *     overall depth ordering.
+ *   • RR/HRV AUTONOMIC (when per-minute `rr` is present) — separates DEEP from REM,
+ *     which HR level CANNOT do on calm nights (REM-HR ≈ light-HR). Deep/SWS = high
+ *     parasympathetic tone → HIGH beat-to-beat variability (RMSSD) + lowest HR; REM =
+ *     parasympathetic withdrawal → REDUCED RMSSD + mildly elevated HR (verified on real
+ *     nights: corr(HR,RMSSD) ≈ −0.4, and a pure-HR stager read REM ≈ 0%). Thresholds are
+ *     RATIOS to the night's asleep-RMSSD median, so they self-calibrate per user:
+ *        deep = RMSSD ≥ 1.15·median  AND  HR ≤ asleep-HR-median
+ *        rem  = RMSSD ≤ 0.88·median  (asleep, below wake)
+ *        light = everything else (the broad majority).
+ *   • Without usable RR we fall back to the legacy HR-only bands (graceful, honest —
+ *     such nights just can't resolve REM, rather than fabricate it).
  * asleep = light+deep+rem; efficiency = asleep / in-bed.
  */
 export function stageSleep(
-  minutes: { ts: number; hr_avg: number }[], onset: number, wake: number, mesor: number,
+  minutes: { ts: number; hr_avg: number; rr?: number[] }[], onset: number, wake: number, mesor: number,
 ): SleepStaging {
   const inBed = Math.max(1, Math.round((wake - onset) / 60));
   const win = minutes.filter((m) => m.ts >= onset && m.ts <= wake).sort((a, b) => a.ts - b.ts);
@@ -195,17 +221,48 @@ export function stageSleep(
   // Light-dominant bands (HR-only stages_beta): deep = only the lowest HR, rem = a
   // narrow elevated band just below wake, light = the broad middle (most of sleep).
   const tAwake = Math.max(floor + 10, floor + 0.70 * span);
-  const tRem = floor + 0.60 * span;
+  // REM = the broad "elevated-but-asleep" band below wake. Anchored at 0.40·span (was
+  // 0.60, which sat just under tAwake → a 2-3 bpm sliver that almost never triggered,
+  // so REM read ~0 on calm nights). REM's HR is only modestly above light, not 60% of
+  // the way to the daytime mesor — 0.40 puts the band where REM actually lives.
+  const tRem = floor + 0.40 * span;
   const tDeep = floor + 0.12 * span;
 
   // smoothed HR aligned to `win` (off-wrist minutes carry hr 0 → forced awake)
   const ys = smooth(win.map((m) => (m.hr_avg > 0 ? m.hr_avg : tAwake + 50)), 5);
+
+  // ── Autonomic axis: per-minute RMSSD (smoothed ±2), and the night's asleep
+  // RMSSD/HR medians as self-calibrating references. Only used if a real fraction of
+  // the asleep minutes carry enough RR — else deep/rem stay on the HR-only fallback. ──
+  const rmRaw = win.map((m) => minuteRmssd(m.rr));
+  const rmS = rmRaw.map((_, i) => {
+    const seg: (number | null)[] = [];
+    for (let j = Math.max(0, i - 2); j < Math.min(win.length, i + 3); j++) seg.push(rmRaw[j]);
+    return medOf(seg);
+  });
+  const asleepI = win.map((_, i) => i).filter((i) => win[i].hr_avg > 0 && ys[i] < tAwake);
+  const rmRef = medOf(asleepI.map((i) => rmS[i]));
+  const hrRef = medOf(asleepI.map((i) => ys[i]));
+  const rrUsable = rmRef != null && hrRef != null
+    && asleepI.filter((i) => rmS[i] != null).length >= Math.max(20, Math.floor(asleepI.length * 0.4));
+  const DEEP_R = 1.15, REM_R = 0.88; // RMSSD ratios vs asleep median (tuned on real RR: REM≈21%, deep≈13%)
+
   const stage: ('awake' | 'light' | 'deep' | 'rem')[] = new Array(win.length).fill('light');
   // pass 1: provisional per-minute classes
   for (let k = 0; k < win.length; k++) {
     if (win[k].hr_avg <= 0) { stage[k] = 'awake'; continue; }
     const v = ys[k];
-    stage[k] = v >= tAwake ? 'awake' : v < tDeep ? 'deep' : v >= tRem ? 'rem' : 'light';
+    if (v >= tAwake) { stage[k] = 'awake'; continue; }
+    if (rrUsable && rmS[k] != null) {
+      // RR present → autonomic deep/rem split (the REM-detecting path).
+      const rm = rmS[k]!;
+      stage[k] = (rm >= DEEP_R * rmRef! && v <= hrRef!) ? 'deep'
+        : (rm <= REM_R * rmRef!) ? 'rem'
+        : 'light';
+    } else {
+      // No usable RR this minute/night → legacy HR-level bands.
+      stage[k] = v < tDeep ? 'deep' : v >= tRem ? 'rem' : 'light';
+    }
   }
   // pass 2: an "awake" minute only counts as awake if part of a SUSTAINED (≥20 min)
   // run; otherwise it's a brief REM/arousal bump → reclassify as rem.
@@ -216,6 +273,32 @@ export function stageSleep(
       if ((win[j - 1].ts - win[k].ts) / 60 < 20) for (let x = k; x < j; x++) stage[x] = 'rem';
       k = j;
     } else k++;
+  }
+  // pass 3: BOUT-SMOOTHING — the per-minute classes flicker when HR hovers near a
+  // threshold (sawtooth hypnogram). Merge any run shorter than MIN_BOUT minutes into
+  // its longer neighbour, repeatedly, so the hypnogram reads as stable sleep bouts
+  // (real stages last many minutes). Awake keeps a higher floor so a genuine short
+  // awakening survives; sub-floor awakes are noise → absorbed into surrounding sleep.
+  const MIN_BOUT = 6, MIN_AWAKE_BOUT = 10;
+  for (let iter = 0; iter < 4; iter++) {
+    const runs: { s: number; e: number }[] = [];
+    for (let i = 0; i < win.length;) { let j = i; while (j < win.length && stage[j] === stage[i]) j++; runs.push({ s: i, e: j - 1 }); i = j; }
+    if (runs.length <= 1) break;
+    let changed = false;
+    for (let r = 0; r < runs.length; r++) {
+      const { s, e } = runs[r];
+      const lenMin = e - s + 1;
+      const floorMin = stage[s] === 'awake' ? MIN_AWAKE_BOUT : MIN_BOUT;
+      if (lenMin >= floorMin) continue;
+      const prev = r > 0 ? runs[r - 1] : null;
+      const next = r < runs.length - 1 ? runs[r + 1] : null;
+      let target: typeof stage[number] | null = null;
+      if (prev && next) target = (prev.e - prev.s) >= (next.e - next.s) ? stage[prev.s] : stage[next.s];
+      else if (prev) target = stage[prev.s];
+      else if (next) target = stage[next.s];
+      if (target) { for (let x = s; x <= e; x++) stage[x] = target; changed = true; }
+    }
+    if (!changed) break;
   }
   let light = 0, deep = 0, rem = 0, awake = 0;
   for (const s of stage) { if (s === 'awake') awake++; else if (s === 'deep') deep++; else if (s === 'rem') rem++; else light++; }

--- a/src/circadian.ts
+++ b/src/circadian.ts
@@ -1,0 +1,199 @@
+// §Circadian — CircaCP (Chen & Sun 2021, arXiv:2111.14960): robust cosinor model
+// of the circadian rhythm + a single bounded change-point per cycle for sleep
+// onset / wake. Validated on the dev account: wake within ~2 min, onset within
+// ~2 min of the Cole-Kripke detector on real WHOOP 1 Hz HR.
+//
+// WHY HR (not actigraphy): the paper uses minute actigraphy, but the method is
+// signal-agnostic and HR carries a strong, clean circadian rhythm (MESOR≈79,
+// amplitude≈13 bpm on the dev account) with a sharp wake transition (HR rises
+// ~25 bpm on waking) — a better wake discriminator than our near-zero activity
+// rollup. Published method, no training, no fabrication; pure & deterministic.
+//
+// Division of labour: this returns the circadian phase + the MAIN-sleep
+// onset/wake boundary of the most-recent completed cycle. In-sleep staging,
+// efficiency and naps stay with calcSleep / calcSleepPeriods over that window.
+import type { Minute, Metric, CircadianValue } from './types';
+import { isHrUsable, clamp, round } from './util';
+
+const DAY = 86400;
+const W = (2 * Math.PI) / DAY; // circadian angular frequency (rad/sec)
+
+interface Pt { t: number; y: number }
+
+/**
+ * Robust cosinor: y ≈ M + b1·cos(ωt) + b2·sin(ωt), fit by IRLS with a Tukey
+ * biweight so the active-phase HR spikes (exercise) don't drag the rhythm.
+ * Returns MESOR M, and (b1,b2) → amplitude = hypot, phase φ = atan2(b2,b1)
+ * with b1·cos+b2·sin = amp·cos(ωt − φ).
+ */
+function fitCosinor(pts: Pt[]): { mesor: number; b1: number; b2: number; amp: number; phi: number } | null {
+  const n = pts.length;
+  if (n < 120) return null; // need at least ~2h of points for a stable fit
+  const rows = pts.map((p) => ({ c: Math.cos(W * p.t), s: Math.sin(W * p.t), y: p.y }));
+  let w = new Array(n).fill(1);
+  let M = 0, b1 = 0, b2 = 0;
+  for (let iter = 0; iter < 8; iter++) {
+    // weighted normal equations for design [1, cos, sin] (3×3)
+    const A = [[0, 0, 0], [0, 0, 0], [0, 0, 0]];
+    const bv = [0, 0, 0];
+    for (let i = 0; i < n; i++) {
+      const x = [1, rows[i].c, rows[i].s];
+      const wi = w[i];
+      for (let r = 0; r < 3; r++) {
+        bv[r] += wi * x[r] * rows[i].y;
+        for (let cc = 0; cc < 3; cc++) A[r][cc] += wi * x[r] * x[cc];
+      }
+    }
+    const sol = solve3(A, bv);
+    if (!sol) return null;
+    [M, b1, b2] = sol;
+    // update biweight weights from residuals (c = 4.685·1.4826·MAD)
+    const res = rows.map((r) => r.y - (M + b1 * r.c + b2 * r.s));
+    const absr = res.map(Math.abs).sort((a, b) => a - b);
+    const mad = absr[absr.length >> 1] || 1;
+    const cc = 4.685 * 1.4826 * mad;
+    w = res.map((e) => (Math.abs(e) < cc ? (1 - (e / cc) ** 2) ** 2 : 0));
+  }
+  return { mesor: M, b1, b2, amp: Math.hypot(b1, b2), phi: Math.atan2(b2, b1) };
+}
+
+/** Solve 3×3 A·x = b by Gaussian elimination with partial pivot. null if singular. */
+function solve3(A: number[][], b: number[]): [number, number, number] | null {
+  const m = A.map((row, i) => [...row, b[i]]);
+  for (let col = 0; col < 3; col++) {
+    let piv = col;
+    for (let r = col + 1; r < 3; r++) if (Math.abs(m[r][col]) > Math.abs(m[piv][col])) piv = r;
+    if (Math.abs(m[piv][col]) < 1e-12) return null;
+    [m[col], m[piv]] = [m[piv], m[col]];
+    const pv = m[col][col];
+    for (let k = col; k < 4; k++) m[col][k] /= pv;
+    for (let r = 0; r < 3; r++) {
+      if (r === col) continue;
+      const f = m[r][col];
+      for (let k = col; k < 4; k++) m[r][k] -= f * m[col][k];
+    }
+  }
+  return [m[0][3], m[1][3], m[2][3]];
+}
+
+/** Median filter (±k) to denoise HR before change-point search. */
+function smooth(ys: number[], k: number): number[] {
+  const n = ys.length;
+  const out = new Array(n);
+  for (let i = 0; i < n; i++) {
+    const lo = Math.max(0, i - k), hi = Math.min(n, i + k + 1);
+    const seg = ys.slice(lo, hi).sort((a, b) => a - b);
+    out[i] = seg[seg.length >> 1];
+  }
+  return out;
+}
+
+/**
+ * Single mean-shift change-point within a bounded window, constrained to a
+ * direction ('drop' = onset, HR falls; 'rise' = wake, HR climbs). Maximises the
+ * SSE reduction of a 2-segment split (binary-segmentation cost). null if the
+ * window is too thin or no shift of the wanted sign exists.
+ */
+function changePoint(pts: Pt[], want: 'drop' | 'rise'): { ts: number; before: number; after: number } | null {
+  const MIN = 15;
+  if (pts.length < 2 * MIN) return null;
+  const ys = smooth(pts.map((p) => p.y), 5);
+  const n = ys.length;
+  const pre = new Array(n + 1).fill(0);
+  const pre2 = new Array(n + 1).fill(0);
+  for (let i = 0; i < n; i++) { pre[i + 1] = pre[i] + ys[i]; pre2[i + 1] = pre2[i] + ys[i] * ys[i]; }
+  const sse = (a: number, b: number): number => {
+    const cnt = b - a; if (cnt <= 0) return 0;
+    const sum = pre[b] - pre[a];
+    return (pre2[b] - pre2[a]) - (sum * sum) / cnt;
+  };
+  const total = sse(0, n);
+  let best: { gain: number; tau: number; ml: number; mr: number } | null = null;
+  for (let tau = MIN; tau < n - MIN; tau++) {
+    const ml = pre[tau] / tau;
+    const mr = (pre[n] - pre[tau]) / (n - tau);
+    const d = mr - ml; // +ve = rise
+    if (want === 'rise' && d <= 0) continue;
+    if (want === 'drop' && d >= 0) continue;
+    const gain = total - (sse(0, tau) + sse(tau, n));
+    if (!best || gain > best.gain) best = { gain, tau, ml, mr };
+  }
+  if (!best) return null;
+  return { ts: pts[best.tau].t, before: best.ml, after: best.mr };
+}
+
+export interface CircadianOpts {
+  now?: number;       // unix s "now" (default = latest minute ts); for determinism
+  settleSec?: number; // a wake older than this = night complete (default 600s)
+  anchorTs?: number;  // target a specific cycle's bathyphase nearest this ts
+}
+
+/**
+ * calcCircadian(minutes, opts)
+ *
+ * Fits the circadian cosinor over the HR series, then for the most-recent
+ * completed cycle (bathyphase = HR trough) finds main-sleep onset (HR drop in
+ * the 8h before the trough) and wake (HR rise in the 8h after). Returns the
+ * circadian phase + that boundary.
+ *
+ * Confidence = rhythm strength (amplitude) × whether a clean onset+wake pair was
+ * found. Abstains (nulls, confidence 0) when the rhythm is too weak or data too
+ * thin — never fabricates a boundary.
+ */
+export function calcCircadian(minutes: Minute[], opts: CircadianOpts = {}): Metric<CircadianValue> {
+  const usable = minutes.filter(isHrUsable).map((m) => ({ t: m.ts, y: m.hr_avg })).sort((a, b) => a.t - b.t);
+  const settle = opts.settleSec ?? 600;
+
+  const empty = (): Metric<CircadianValue> => ({
+    mesor: null, amplitude: null, acrophase_ts: null, bathyphase_ts: null,
+    onset_ts: null, wake_ts: null, in_bed_min: 0, settled: false,
+    confidence: 0, tier: 'HIGH', inputs_used: [],
+  });
+  if (usable.length < 120) return empty();
+
+  const now = opts.now ?? usable[usable.length - 1].t;
+  const fit = fitCosinor(usable);
+  if (!fit) return empty();
+
+  // bathyphase (HR trough): amp·cos(ωt − φ) minimal → ωt − φ = π.
+  const bathBase = (fit.phi + Math.PI) / W;
+  // acrophase (HR peak): ωt − φ = 0.
+  const acroBase = fit.phi / W;
+  const nearest = (base: number, ref: number) => base + Math.round((ref - base) / DAY) * DAY;
+
+  // Pick the cycle: target anchor, else the most-recent bathyphase whose +8h wake
+  // window has settled (so we close completed nights, not the one in progress).
+  const anchor = opts.anchorTs ?? now - settle;
+  let bath = nearest(bathBase, anchor);
+  // If that cycle's wake window hasn't settled yet, step back one cycle.
+  if (bath + 8 * 3600 > now - settle) bath -= DAY;
+  const acro = nearest(acroBase, now);
+
+  const inWin = (lo: number, hi: number) => usable.filter((p) => p.t >= lo && p.t <= hi);
+  const onset = changePoint(inWin(bath - 8 * 3600, bath), 'drop');
+  const wake = changePoint(inWin(bath, bath + 8 * 3600), 'rise');
+
+  const onset_ts = onset ? onset.ts : null;
+  const wake_ts = wake ? wake.ts : null;
+  const in_bed_min = onset_ts != null && wake_ts != null ? Math.round((wake_ts - onset_ts) / 60) : 0;
+  const settled = wake_ts != null && wake_ts <= now - settle;
+
+  // confidence: rhythm strength (amp 2→0 … 10→1) gated on a clean onset+wake pair.
+  const rhythm = clamp((fit.amp - 2) / 8, 0, 1);
+  const paired = onset_ts != null && wake_ts != null ? 1 : 0.3;
+  const confidence = round(rhythm * paired, 2);
+
+  return {
+    mesor: round(fit.mesor, 1),
+    amplitude: round(fit.amp, 1),
+    acrophase_ts: acro,
+    bathyphase_ts: bath,
+    onset_ts,
+    wake_ts,
+    in_bed_min,
+    settled,
+    confidence,
+    tier: 'HIGH',
+    inputs_used: ['hr'],
+  };
+}

--- a/src/circadian.ts
+++ b/src/circadian.ts
@@ -158,40 +158,73 @@ function mainSleepPeriod(pts: Pt[], bath: number, mesor: number): { onset: numbe
   return { onset, wake: pts[end].t };
 }
 
+export interface SleepStaging {
+  in_bed_min: number; asleep_min: number; efficiency: number;
+  awake_min: number; light_min: number; deep_min: number; rem_min: number;
+  hypnogram: { t: number; stage: 'awake' | 'light' | 'deep' | 'rem' }[];
+}
+
 /**
- * Sleep efficiency / WASO over a fixed [onset, wake] window, HR-only (ESTIMATE).
- * WASO = minutes in SUSTAINED elevations (≥15 min) above a threshold set partway
- * between the night's sleeping floor (20th-pctile HR) and the cosinor mesor — so
- * brief REM/arousal bumps don't count, but prolonged wakefulness does. asleep =
- * worn − WASO; efficiency = asleep / in-bed. Honest middle ground for HR-only: it
- * neither pins efficiency at 1.0 (mesor-only) nor calls every REM bump "awake".
+ * The ONE sleep stager (HR-only, ESTIMATE/beta). Classifies every minute in
+ * [onset, wake] into awake / light / deep / rem off thresholds anchored between the
+ * night's sleeping floor (10th-pctile HR) and the cosinor mesor, then returns BOTH
+ * the per-minute hypnogram AND the reconciled totals — so the graph and the stage
+ * breakdown can never disagree (the previous bug: two different classifiers).
+ *
+ *   awake = SUSTAINED (≥20 min) HR ≥ floor+0.70·(mesor−floor), or off-wrist — only
+ *           clear near-wake elevations, never normal light/REM HR.
+ *   deep  = HR < floor+0.20·(mesor−floor)         (lowest)
+ *   rem   = floor+0.45·(mesor−floor) ≤ HR < awake (elevated but asleep)
+ *   light = everything else.
+ * asleep = light+deep+rem; efficiency = asleep / in-bed.
  */
-export function sleepEfficiency(
+export function stageSleep(
   minutes: { ts: number; hr_avg: number }[], onset: number, wake: number, mesor: number,
-): { in_bed_min: number; asleep_min: number; efficiency: number; waso_min: number } {
+): SleepStaging {
   const inBed = Math.max(1, Math.round((wake - onset) / 60));
-  const win = minutes.filter((m) => m.ts >= onset && m.ts <= wake && m.hr_avg > 0)
-    .sort((a, b) => a.ts - b.ts);
-  const worn = win.length;
-  if (worn < 5) return { in_bed_min: inBed, asleep_min: worn, efficiency: clamp(worn / inBed, 0, 1), waso_min: 0 };
-  const hrs = win.map((m) => m.hr_avg);
-  // WASO threshold sits HIGH — 0.70 of the way from the sleeping floor to the mesor —
-  // so only clear, near-wake elevations count as awake, not normal light/REM sleep HR
-  // (which for high-sleeping-HR users sits well above the floor). Sustained ≥20 min.
+  const win = minutes.filter((m) => m.ts >= onset && m.ts <= wake).sort((a, b) => a.ts - b.ts);
+  const empty: SleepStaging = {
+    in_bed_min: inBed, asleep_min: 0, efficiency: 0, awake_min: inBed,
+    light_min: 0, deep_min: 0, rem_min: 0, hypnogram: [],
+  };
+  const worn = win.filter((m) => m.hr_avg > 0);
+  if (worn.length < 5) return empty;
+  const hrs = worn.map((m) => m.hr_avg);
   const floor = percentile(hrs, 10) ?? Math.min(...hrs);
-  const threshold = Math.max(floor + 10, floor + 0.70 * (mesor - floor));
-  const ys = smooth(hrs, 5);
-  let waso = 0, i = 0;
-  while (i < ys.length) {
-    if (ys[i] >= threshold) {
-      let j = i;
-      while (j < ys.length && ys[j] >= threshold) j++;
-      if ((win[j - 1].ts - win[i].ts) / 60 >= 20) waso += j - i; // sustained → count as awake
-      i = j;
-    } else i++;
+  const span = Math.max(1, mesor - floor);
+  // Light-dominant bands (HR-only stages_beta): deep = only the lowest HR, rem = a
+  // narrow elevated band just below wake, light = the broad middle (most of sleep).
+  const tAwake = Math.max(floor + 10, floor + 0.70 * span);
+  const tRem = floor + 0.60 * span;
+  const tDeep = floor + 0.12 * span;
+
+  // smoothed HR aligned to `win` (off-wrist minutes carry hr 0 → forced awake)
+  const ys = smooth(win.map((m) => (m.hr_avg > 0 ? m.hr_avg : tAwake + 50)), 5);
+  const stage: ('awake' | 'light' | 'deep' | 'rem')[] = new Array(win.length).fill('light');
+  // pass 1: provisional per-minute classes
+  for (let k = 0; k < win.length; k++) {
+    if (win[k].hr_avg <= 0) { stage[k] = 'awake'; continue; }
+    const v = ys[k];
+    stage[k] = v >= tAwake ? 'awake' : v < tDeep ? 'deep' : v >= tRem ? 'rem' : 'light';
   }
-  const asleep = Math.max(0, worn - waso);
-  return { in_bed_min: inBed, asleep_min: asleep, efficiency: clamp(asleep / inBed, 0, 1), waso_min: waso };
+  // pass 2: an "awake" minute only counts as awake if part of a SUSTAINED (≥20 min)
+  // run; otherwise it's a brief REM/arousal bump → reclassify as rem.
+  let k = 0;
+  while (k < win.length) {
+    if (stage[k] === 'awake' && win[k].hr_avg > 0) {
+      let j = k; while (j < win.length && stage[j] === 'awake' && win[j].hr_avg > 0) j++;
+      if ((win[j - 1].ts - win[k].ts) / 60 < 20) for (let x = k; x < j; x++) stage[x] = 'rem';
+      k = j;
+    } else k++;
+  }
+  let light = 0, deep = 0, rem = 0, awake = 0;
+  for (const s of stage) { if (s === 'awake') awake++; else if (s === 'deep') deep++; else if (s === 'rem') rem++; else light++; }
+  const asleep = light + deep + rem;
+  return {
+    in_bed_min: inBed, asleep_min: asleep, efficiency: clamp(asleep / inBed, 0, 1),
+    awake_min: awake, light_min: light, deep_min: deep, rem_min: rem,
+    hypnogram: win.map((m, idx) => ({ t: m.ts, stage: stage[idx] })),
+  };
 }
 
 export interface CircadianOpts {

--- a/src/cycle.ts
+++ b/src/cycle.ts
@@ -1,0 +1,100 @@
+// cycle.ts — menstrual cycle estimation.
+//
+// LOG-ANCHORED + calendar method: the user logs period-start dates; prediction is
+// driven by those, never inferred from biometrics alone (we don't claim to detect
+// ovulation from temperature — that would be fabrication). The luteal phase is
+// physiologically stable at ~14 days (Wilcox 2000), so ovulation ≈ next-period − 14
+// and the fertile window is the 5 days before ovulation + ovulation day.
+//
+// Biometric overlay (skin-temp / RHR / HRV shifts across the cycle) is rendered by
+// the caller from stored `daily` values — it ENRICHES the view but is descriptive,
+// never the basis of the prediction. Honest: an ESTIMATE, not medical or
+// contraceptive guidance.
+
+import type { Metric } from './types'
+import { median } from './util'
+
+const DAY_MS = 86400000
+const toMs = (d: string) => Date.parse(d + 'T00:00:00Z')
+const toDate = (ms: number) => new Date(ms).toISOString().slice(0, 10)
+const daysBetween = (a: string, b: string) => Math.round((toMs(b) - toMs(a)) / DAY_MS)
+
+export type CyclePhase = 'menstruation' | 'follicular' | 'ovulation' | 'luteal' | 'unknown'
+
+export interface CycleValue {
+  cycle_day: number | null      // 1-based day within the current cycle (day 1 = start)
+  phase: CyclePhase
+  mean_length: number | null    // median observed cycle length (days); null if <2 starts
+  length_history: number[]      // observed consecutive-start gaps (days)
+  last_start: string | null     // most recent logged period start (YYYY-MM-DD)
+  predicted_next: string | null // predicted next period start
+  days_until_next: number | null
+  ovulation_est: string | null  // predicted_next − 14d
+  fertile_start: string | null  // ovulation − 5d
+  fertile_end: string | null    // ovulation + 1d
+  note: string
+}
+
+const DEFAULT_LEN = 28 // population default until the user has ≥2 logged periods
+const LUTEAL = 14      // stable luteal length → ovulation = next_period − LUTEAL
+const MENSES = 5       // assumed menses length when no explicit end is logged
+
+/** Estimate the current cycle position + next-period / fertile-window prediction
+ *  from a list of logged period-START dates. `today` is supplied (pure, no clock). */
+export function calcCycle(startsRaw: string[], today: string): Metric<CycleValue> {
+  const empty = (note: string): Metric<CycleValue> => ({
+    cycle_day: null, phase: 'unknown', mean_length: null, length_history: [],
+    last_start: null, predicted_next: null, days_until_next: null,
+    ovulation_est: null, fertile_start: null, fertile_end: null, note,
+    confidence: 0, tier: 'ESTIMATE', inputs_used: ['period_log'],
+  })
+
+  const starts = Array.from(new Set(startsRaw))
+    .filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d) && toMs(d) <= toMs(today))
+    .sort()
+  if (starts.length === 0) return empty('Log a period to start tracking your cycle.')
+
+  // Observed cycle lengths between consecutive starts (keep physiological 15–60d).
+  const lengths: number[] = []
+  for (let i = 1; i < starts.length; i++) {
+    const len = daysBetween(starts[i - 1], starts[i])
+    if (len >= 15 && len <= 60) lengths.push(len)
+  }
+  const med = lengths.length ? median(lengths) : null
+  const meanLen = med == null ? null : Math.round(med)
+  const useLen = meanLen ?? DEFAULT_LEN
+
+  const last = starts[starts.length - 1]
+  const cycleDay = daysBetween(last, today) + 1 // day 1 = the start date itself
+
+  const nextMs = toMs(last) + useLen * DAY_MS
+  const predictedNext = toDate(nextMs)
+  const daysUntil = daysBetween(today, predictedNext)
+  const ovMs = nextMs - LUTEAL * DAY_MS
+  const ovulation = toDate(ovMs)
+  const fertileStart = toDate(ovMs - 5 * DAY_MS)
+  const fertileEnd = toDate(ovMs + 1 * DAY_MS)
+
+  // Phase by calendar method.
+  const todayMs = toMs(today)
+  let phase: CyclePhase
+  if (cycleDay <= MENSES) phase = 'menstruation'
+  else if (todayMs >= toMs(fertileStart) && todayMs <= toMs(fertileEnd)) phase = 'ovulation'
+  else if (todayMs < ovMs) phase = 'follicular'
+  else phase = 'luteal'
+
+  // Confidence grows with the number of observed cycles; collapses if very overdue
+  // (a missed/late period makes the calendar prediction unreliable — say so).
+  let conf = lengths.length === 0 ? 0.3 : Math.min(0.9, 0.4 + 0.15 * lengths.length)
+  if (cycleDay > useLen * 1.6) { phase = 'unknown'; conf = Math.min(conf, 0.2) }
+
+  return {
+    cycle_day: cycleDay, phase, mean_length: meanLen, length_history: lengths,
+    last_start: last, predicted_next: predictedNext, days_until_next: daysUntil,
+    ovulation_est: ovulation, fertile_start: fertileStart, fertile_end: fertileEnd,
+    note: lengths.length === 0
+      ? 'Based on one logged period and a 28-day default — accuracy improves as you log more.'
+      : `Based on ${lengths.length + 1} logged periods (median ${useLen}-day cycle).`,
+    confidence: conf, tier: 'ESTIMATE', inputs_used: ['period_log'],
+  }
+}

--- a/src/cycles.ts
+++ b/src/cycles.ts
@@ -1,0 +1,108 @@
+// §Sleep cycles — ultradian NREM↔REM cycle detection, adapted from Rosenblum et al.
+// 2024 (eLife 13:RP96784, "Fractal cycles of sleep").
+//
+// The paper detects sleep cycles as the interval between successive PEAKS of the
+// smoothed, z-normalized EEG *aperiodic (fractal) slope* time series — MATLAB
+// findpeaks(MinPeakDistance = 20 min, MinPeakProminence = 0.9 z). Peaks coincide with
+// REM, troughs with non-REM; ~4–6 cycles/night, ~90 min each. It's a continuous,
+// parameter-light definition with NO arbitrary per-night knob — exactly the property
+// we want.
+//
+// We have no EEG. But heart-rate VARIABILITY carries the SAME ultradian rhythm — RMSSD
+// is high in deep non-REM and low in REM — so we run the IDENTICAL peak algorithm on
+// the smoothed z-normalized per-minute RMSSD series. Cycle boundaries anchor on the
+// deep-sleep RMSSD peaks (the paper anchors on REM peaks: a cosmetic half-cycle phase
+// shift — the cycle COUNT and DURATION, the actual outputs, are unchanged).
+//
+// Pure & deterministic. Tier ESTIMATE (it's a wrist-HRV proxy for an EEG method).
+import { cleanRr } from './hrv';
+
+export interface SleepCycle { start_ts: number; end_ts: number; duration_min: number }
+export interface SleepCyclesValue {
+  cycles: SleepCycle[];
+  mean_duration_min: number | null;
+  n: number;
+  series: { t: number; z: number }[]; // smoothed z-RMSSD, for plotting under the hypnogram
+}
+
+const SMOOTH_MIN = 10;       // ±10-min moving average → exposes the ~90-min envelope
+const MIN_PEAK_DIST = 20;    // min minutes between cycle boundaries (paper: 20 min / 40×30s)
+const MIN_PROMINENCE = 0.9;  // z — paper's MinPeakProminence (the |0.9| z descent gate)
+
+/** Per-minute RMSSD (ms) from a raw RR stream; null if too few clean beats. */
+function minuteRmssd(rr: number[] | undefined): number | null {
+  if (!rr || rr.length < 12) return null;
+  const c = cleanRr(rr);
+  if (c.length < 10) return null;
+  let s = 0;
+  for (let i = 1; i < c.length; i++) { const d = c[i] - c[i - 1]; s += d * d; }
+  return Math.sqrt(s / (c.length - 1));
+}
+
+/** Local maxima with topographic prominence ≥ minProm, then enforce a minimum spacing
+ *  (keep the highest in each cluster) — a faithful port of MATLAB findpeaks' two gates. */
+function findPeaks(y: (number | null)[], minDist: number, minProm: number): number[] {
+  const n = y.length;
+  const cand: { i: number; v: number }[] = [];
+  for (let i = 1; i < n - 1; i++) {
+    const yi = y[i]; if (yi == null) continue;
+    const a = y[i - 1] ?? -Infinity, b = y[i + 1] ?? -Infinity;
+    if (!(yi >= a && yi > b)) continue;
+    // prominence: walk out each side until a higher sample; the higher of the two
+    // in-between minima is the reference. prom = peak − that reference.
+    let l = i; while (l > 0 && (y[l - 1] ?? -Infinity) < yi) l--;
+    let r = i; while (r < n - 1 && (y[r + 1] ?? -Infinity) < yi) r++;
+    let lmin = yi, rmin = yi;
+    for (let k = l; k <= i; k++) { const v = y[k]; if (v != null && v < lmin) lmin = v; }
+    for (let k = i; k <= r; k++) { const v = y[k]; if (v != null && v < rmin) rmin = v; }
+    if (yi - Math.max(lmin, rmin) >= minProm) cand.push({ i, v: yi });
+  }
+  cand.sort((p, q) => q.v - p.v); // tallest first
+  const kept: number[] = [];
+  for (const c of cand) if (kept.every((k) => Math.abs(c.i - k) >= minDist)) kept.push(c.i);
+  return kept.sort((a, b) => a - b);
+}
+
+/**
+ * detectSleepCycles(minutes, onset, wake)
+ * minutes: per-minute records over (at least) the sleep window, each with optional `rr`.
+ * Returns the ultradian cycles (peak-to-peak), their mean duration, and the smoothed
+ * z-RMSSD series. Abstains (empty) when there isn't enough clean RR to resolve cycles.
+ */
+export function detectSleepCycles(
+  minutes: { ts: number; rr?: number[] }[], onset: number, wake: number,
+): SleepCyclesValue {
+  const none: SleepCyclesValue = { cycles: [], mean_duration_min: null, n: 0, series: [] };
+  const win = minutes.filter((m) => m.ts >= onset && m.ts <= wake).sort((a, b) => a.ts - b.ts);
+  if (win.length < 60) return none; // need ~1 h to resolve even one cycle
+
+  const raw = win.map((m) => minuteRmssd(m.rr));
+  // ±SMOOTH_MIN moving average (ignoring gaps).
+  const sm = raw.map((_, i) => {
+    let s = 0, c = 0;
+    for (let j = Math.max(0, i - SMOOTH_MIN); j <= Math.min(raw.length - 1, i + SMOOTH_MIN); j++) {
+      const v = raw[j]; if (v != null) { s += v; c++; }
+    }
+    return c ? s / c : null;
+  });
+  const vals = sm.filter((x): x is number => x != null);
+  if (vals.length < 60) return none;
+  const mean = vals.reduce((a, b) => a + b, 0) / vals.length;
+  const sd = Math.sqrt(vals.reduce((a, b) => a + (b - mean) ** 2, 0) / vals.length) || 1;
+  const z = sm.map((x) => (x == null ? null : (x - mean) / sd));
+
+  const peaks = findPeaks(z, MIN_PEAK_DIST, MIN_PROMINENCE);
+  const cycles: SleepCycle[] = [];
+  for (let i = 0; i + 1 < peaks.length; i++) {
+    const start_ts = win[peaks[i]].ts, end_ts = win[peaks[i + 1]].ts;
+    cycles.push({ start_ts, end_ts, duration_min: Math.round((end_ts - start_ts) / 60) });
+  }
+  const mean_duration_min = cycles.length
+    ? Math.round(cycles.reduce((s, c) => s + c.duration_min, 0) / cycles.length) : null;
+  const series = win
+    .map((m, i) => ({ t: m.ts, z: z[i] }))
+    .filter((p): p is { t: number; z: number } => p.z != null)
+    .map((p) => ({ t: p.t, z: Math.round(p.z * 1000) / 1000 }));
+
+  return { cycles, mean_duration_min, n: cycles.length, series };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,10 @@ export type {
 // §12 Stress — HRV-based (Baevsky Stress Index + LF/HF, personal-relative).
 export { calcStress } from './stress';
 
+// §SpO₂ — RELATIVE blood-oxygen index from the red/IR reflectance ratio.
+export { calcSpo2Index } from './spo2';
+export type { Spo2Value } from './spo2';
+
 // §Sleep stress / nocturnal arousal (HR surge + motion during sleep).
 export { calcSleepStress } from './arousal';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,10 @@ export { calcVo2Max, calcFitnessModel, calcMonotony } from './fitness';
 // §Steps — AN-2554 wrist pedometer (pure math; backend re-decodes the IMU + runs it)
 export { calcSteps, pedometer, STEP_PARAMS } from './steps';
 
+// §Circadian — CircaCP cosinor + bounded change-point (physiological-day anchor)
+export { calcCircadian } from './circadian';
+export type { CircadianOpts } from './circadian';
+
 // §Composite Readiness — weighted HRV + sleep blend (abstains without HRV)
 export { calcReadinessIndex } from './readiness_index';
 export type { ReadinessInputs } from './readiness_index';

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,11 @@ export { calcSteps, pedometer, STEP_PARAMS } from './steps';
 export { calcCircadian, stageSleep } from './circadian';
 export type { CircadianOpts, SleepStaging } from './circadian';
 
+// §Sleep/wake ENSEMBLE — pluggable voters (Cole-Kripke + cardiac/CPD + van Hees);
+// drives the demand-driven day-close trigger. detectWakeState + cheap peekRecentState.
+export { detectWakeState, peekRecentState, coleKripke, cardiac, inactivity, DEFAULT_VOTERS } from './wake';
+export type { WakeContext, WakeState, WakeLabel, Voter } from './wake';
+
 // §Composite Readiness — weighted HRV + sleep blend (abstains without HRV)
 export { calcReadinessIndex } from './readiness_index';
 export type { ReadinessInputs } from './readiness_index';

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,8 @@ export { calcVo2Max, calcFitnessModel, calcMonotony } from './fitness';
 export { calcSteps, pedometer, STEP_PARAMS } from './steps';
 
 // §Circadian — CircaCP cosinor + bounded change-point (physiological-day anchor)
-export { calcCircadian, sleepEfficiency } from './circadian';
-export type { CircadianOpts } from './circadian';
+export { calcCircadian, stageSleep } from './circadian';
+export type { CircadianOpts, SleepStaging } from './circadian';
 
 // §Composite Readiness — weighted HRV + sleep blend (abstains without HRV)
 export { calcReadinessIndex } from './readiness_index';

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,14 @@ export { calcCalories } from './calories';
 export { calcSleep } from './sleep';
 // §5b Sleep v2 — multi-period (naps = shorter sleeps). Additive; calcSleep unchanged.
 export { calcSleepPeriods } from './sleep';
+// Per-minute asleep/awake mask (calcSleep's boundary) — reconciles the hypnogram's awake.
+export { sleepAwakeMask } from './sleep';
+// v1-method per-minute hypnogram (Cole-Kripke + HR-percentile bands) — single source.
+export { stageHypnogram } from './sleep';
+export type { NightHypnogram } from './sleep';
+// §Sleep cycles — ultradian NREM↔REM cycles (Rosenblum 2024 fractal-cycle method, HRV-adapted).
+export { detectSleepCycles } from './cycles';
+export type { SleepCycle, SleepCyclesValue } from './cycles';
 
 // §6 Sleep regularity (SRI)
 export { calcSleepRegularity } from './regularity';

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export { calcVo2Max, calcFitnessModel, calcMonotony } from './fitness';
 export { calcSteps, pedometer, STEP_PARAMS } from './steps';
 
 // §Circadian — CircaCP cosinor + bounded change-point (physiological-day anchor)
-export { calcCircadian } from './circadian';
+export { calcCircadian, sleepEfficiency } from './circadian';
 export type { CircadianOpts } from './circadian';
 
 // §Composite Readiness — weighted HRV + sleep blend (abstains without HRV)

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,10 @@ export type { NightHypnogram } from './sleep';
 export { detectSleepCycles } from './cycles';
 export type { SleepCycle, SleepCyclesValue } from './cycles';
 
+// §Menstrual cycle — log-anchored calendar method + fertile window (Wilcox 2000).
+export { calcCycle } from './cycle';
+export type { CycleValue, CyclePhase } from './cycle';
+
 // §6 Sleep regularity (SRI)
 export { calcSleepRegularity } from './regularity';
 

--- a/src/sleep.ts
+++ b/src/sleep.ts
@@ -5,9 +5,25 @@ import type {
   SleepPeriod, SleepPeriodsValue,
 } from './types';
 import { isHrUsable, mean, round } from './util';
+import { cleanRr } from './hrv';
 
 // Cole-Kripke weights over window [-4..+2].
 const CK_W = [1.06, 0.54, 0.58, 0.76, 2.3, 0.74, 0.67];
+
+/** Per-minute RMSSD (ms) from a raw RR stream; null if too few clean beats. */
+function minuteRmssd(rr: number[] | undefined): number | null {
+  if (!rr || rr.length < 12) return null;
+  const c = cleanRr(rr);
+  if (c.length < 10) return null;
+  let s = 0;
+  for (let i = 1; i < c.length; i++) { const d = c[i] - c[i - 1]; s += d * d; }
+  return Math.sqrt(s / (c.length - 1));
+}
+function medOfNullable(xs: (number | null)[]): number | null {
+  const a = xs.filter((x): x is number => x != null && Number.isFinite(x)).sort((p, q) => p - q);
+  return a.length ? a[a.length >> 1] : null;
+}
+const REM_RMSSD_FACTOR = 0.90; // high-HR minute with smoothed RMSSD < 0.90×asleep-median = REM, not wake
 
 /**
  * calcSleep(minutes, baseline)
@@ -341,6 +357,148 @@ export function calcSleepPeriods(minutes: Minute[], baseline: Baseline): Metric<
     confidence: periods[main_idx].confidence,
     tier: 'HIGH',
     inputs_used,
+  };
+}
+
+/**
+ * sleepAwakeMask(minutes, baseline, rrByMin?) → Map<ts, asleep:boolean> per minute.
+ * Cole-Kripke actigraphy + HR-dip — the authoritative asleep/awake boundary — PLUS an
+ * RR tiebreaker for the override's blind spot:
+ *
+ * The HR-dip rule "HR > 1.15·rhr ⇒ awake" is right for genuine wake but it ALSO catches
+ * REM (REM HR legitimately runs ~15% above the sleeping floor) — and on a calm wrist with
+ * a near-dead activity signal there's no movement to tell them apart, so REM gets called
+ * "awake". Fix: for those high-HR minutes, look at beat-to-beat RR. REM = parasympathetic
+ * withdrawal ⇒ LOW RMSSD; so a high-HR minute whose smoothed RMSSD is below 0.90× the
+ * night's asleep-RMSSD median is REM → stays ASLEEP, not awake. (rrByMin optional; without
+ * it the legacy HR-only override stands.)
+ *
+ * The day-detail uses this to drive the hypnogram + breakdown from one source. Empty map
+ * when there's no resting-HR baseline. calcSleep/calcSleepPeriods scorers stay untouched.
+ */
+export function sleepAwakeMask(
+  minutes: Minute[], baseline: Baseline, rrByMin?: Map<number, number[]>,
+): Map<number, boolean> {
+  const out = new Map<number, boolean>();
+  const rhr = baseline.resting_hr;
+  if (rhr == null || rhr <= 0) return out;
+  const sorted = [...minutes].sort((a, b) => a.ts - b.ts);
+  const n = sorted.length;
+
+  // Per-minute smoothed RMSSD + the asleep-RMSSD median → the REM cut for the tiebreaker.
+  let rms: (number | null)[] = [];
+  let remCut: number | null = null;
+  if (rrByMin && rrByMin.size) {
+    const raw = sorted.map((m) => minuteRmssd(rrByMin.get(m.ts)));
+    rms = raw.map((_, i) => medOfNullable(raw.slice(Math.max(0, i - 2), Math.min(n, i + 3))));
+    const asleepRms = sorted.map((m, i) => (m.hr_avg > 0 ? rms[i] : null));
+    const med = medOfNullable(asleepRms);
+    if (med != null) remCut = REM_RMSSD_FACTOR * med;
+  }
+
+  for (let i = 0; i < n; i++) {
+    let s = 0;
+    for (let k = 0; k < CK_W.length; k++) {
+      const idx = i + (k - 4);
+      if (idx >= 0 && idx < n) s += CK_W[k] * sorted[idx].activity;
+    }
+    s *= 0.001;
+    const m = sorted[i];
+    if (!m.wrist_on) { out.set(m.ts, false); continue; } // off-wrist = not asleep (boundary)
+    let isAsleep = s < 1;
+    if (m.hr_avg > 0) {
+      if (m.hr_avg < 0.95 * rhr) isAsleep = true;
+      else if (m.hr_avg > 1.15 * rhr) {
+        // RR tiebreaker: high HR + low RMSSD = REM (asleep); else genuine wake.
+        const remLike = remCut != null && rms[i] != null && rms[i]! < remCut;
+        isAsleep = remLike;
+      }
+    }
+    out.set(m.ts, isAsleep);
+  }
+  return out;
+}
+
+/** Merge per-minute stage runs shorter than the floor into the larger neighbour
+ *  (awake keeps a higher floor) — consolidates the per-minute classifier's flicker
+ *  into stable bouts so the hypnogram doesn't sawtooth. */
+function boutSmoothStage(labels: string[], minRun = 5, minAwakeRun = 7, passes = 6): string[] {
+  const s = [...labels];
+  for (let p = 0; p < passes; p++) {
+    const runs: { a: number; b: number }[] = [];
+    for (let i = 0; i < s.length;) { let j = i; while (j < s.length && s[j] === s[i]) j++; runs.push({ a: i, b: j - 1 }); i = j; }
+    if (runs.length <= 1) break;
+    let changed = false;
+    for (let r = 0; r < runs.length; r++) {
+      const { a, b } = runs[r];
+      const floor = s[a] === 'awake' ? minAwakeRun : minRun;
+      if (b - a + 1 >= floor) continue;
+      const prev = r > 0 ? runs[r - 1] : null;
+      const next = r < runs.length - 1 ? runs[r + 1] : null;
+      let tgt: string | null = null;
+      if (prev && next) tgt = (prev.b - prev.a) >= (next.b - next.a) ? s[prev.a] : s[next.a];
+      else if (prev) tgt = s[prev.a];
+      else if (next) tgt = s[next.a];
+      if (tgt) { for (let x = a; x <= b; x++) s[x] = tgt; changed = true; }
+    }
+    if (!changed) break;
+  }
+  return s;
+}
+
+export interface NightHypnogram {
+  hypnogram: { t: number; stage: 'awake' | 'light' | 'deep' | 'rem' }[];
+  light_min: number; deep_min: number; rem_min: number; awake_min: number; asleep_min: number;
+}
+
+/**
+ * stageHypnogram(minutes, onset, wake, baseline) — the v1 staging method, made
+ * per-minute and consistent. ONE source for the whole hypnogram + breakdown:
+ *   • asleep/awake from calcSleep's Cole-Kripke + HR-dip mask (the proven detector),
+ *   • deep/light/rem within the asleep minutes from the SAME HR-percentile bands as
+ *     estimateStages (deep = bottom ~22% of sleeping HR, REM = top ~21%, else light),
+ *   • bout-smoothed so it reads as stable bouts, not minute flicker.
+ * No RR, no circadian, no second stager — exactly what worked in v1, now driving both
+ * the graph and the totals (so they can never disagree). null if no resting-HR baseline.
+ */
+export function stageHypnogram(
+  minutes: Minute[], onset: number, wake: number, baseline: Baseline, rrByMin?: Map<number, number[]>,
+): NightHypnogram | null {
+  const rhr = baseline.resting_hr;
+  if (rhr == null || rhr <= 0) return null;
+  const mask = sleepAwakeMask(minutes, baseline, rrByMin); // ts → asleep (REM tiebreaker via RR)
+  const win = minutes.filter((m) => m.ts >= onset && m.ts <= wake).sort((a, b) => a.ts - b.ts);
+  if (win.length < 5) return null;
+
+  // HR-percentile bands over the night's OWN sleeping HR (same as estimateStages).
+  const sleepHr = win.filter((m) => mask.get(m.ts) !== false && m.hr_avg > 0).map((m) => m.hr_avg);
+  const hrs = sleepHr.length ? sleepHr : win.filter((m) => m.hr_avg > 0).map((m) => m.hr_avg);
+  const sortedHr = [...hrs].sort((a, b) => a - b);
+  const meanHr = hrs.length ? hrs.reduce((a, b) => a + b, 0) / hrs.length : rhr;
+  const q = (p: number): number => sortedHr.length ? sortedHr[Math.min(sortedHr.length - 1, Math.floor(p * sortedHr.length))] : meanHr;
+  const deepEdge = q(0.22), remEdge = q(0.79);
+  const bigJump = Math.max(6, (hrs.length ? Math.max(1, q(0.9) - q(0.1)) : 1) * 0.6);
+  const acts = win.map((m) => m.activity);
+  const meanAct = acts.reduce((a, b) => a + b, 0) / (acts.length || 1);
+
+  const raw: string[] = win.map((m, i) => {
+    if (mask.get(m.ts) === false || m.hr_avg <= 0) return 'awake';
+    const hr = m.hr_avg;
+    const prev = i > 0 && win[i - 1].hr_avg > 0 ? win[i - 1].hr_avg : hr;
+    const next = i + 1 < win.length && win[i + 1].hr_avg > 0 ? win[i + 1].hr_avg : hr;
+    const hrJump = Math.max(Math.abs(hr - prev), Math.abs(hr - next));
+    const lowAct = m.activity <= meanAct;
+    if (lowAct && hr <= deepEdge) return 'deep';
+    if (lowAct && hr >= remEdge) return 'rem';
+    if (lowAct && hrJump > bigJump) return 'rem';
+    return 'light';
+  });
+  const sm = boutSmoothStage(raw);
+  let light = 0, deep = 0, rem = 0, awake = 0;
+  for (const s of sm) { if (s === 'awake') awake++; else if (s === 'deep') deep++; else if (s === 'rem') rem++; else light++; }
+  return {
+    hypnogram: win.map((m, i) => ({ t: m.ts, stage: sm[i] as 'awake' | 'light' | 'deep' | 'rem' })),
+    light_min: light, deep_min: deep, rem_min: rem, awake_min: awake, asleep_min: light + deep + rem,
   };
 }
 

--- a/src/spo2.ts
+++ b/src/spo2.ts
@@ -1,0 +1,65 @@
+// §SpO₂ — RELATIVE blood-oxygen index from the red/IR reflectance ratio.
+//
+// Pulse oximetry is grounded in the ratio R = red/IR: dividing the two LED
+// channels cancels common-mode (perfusion, skin tone, contact, motion) that a
+// single channel conflates. We do NOT have factory LED/photodiode calibration,
+// and the 1 Hz historical record can't resolve the cardiac AC for a true
+// ratio-of-ratios — so this is a RELATIVE index (tonight's median R vs the
+// user's own baseline R), never an absolute %. Validated on 4 user datasets:
+// the ratio is more stable than red-alone on clean signal (CV 0.79–4.81% vs
+// 0.99–5.53%); on a noisy band it isn't, which is why the confidence below
+// is gated on intra-night ratio stability + sample count — a noisy night
+// yields low confidence (or null), never a misleading number.
+import type { Metric, Driver, MetricRef } from './types';
+import { median, mean, stddev, round, clamp } from './util';
+
+export interface Spo2Value {
+  /** Relative deviation vs personal baseline, in % of baseline ratio.
+   *  Signed so that POSITIVE = better-oxygenated than your baseline (lower R). */
+  index: number | null;
+  /** Tonight's median red/IR ratio (raw) — kept so the caller can roll the baseline. */
+  night_ratio: number | null;
+}
+
+const MIN_MINUTES = 30;       // need ≥30 one-minute ratios for a defensible night
+const PLAUSIBLE = (r: number) => r > 0.4 && r < 1.5; // reflectance-ratio sanity band
+const CV_FLOOR = 0.08;        // intra-night CV at/above which confidence → 0
+
+/**
+ * calcSpo2Index(ratios, baselineRatio)
+ *
+ * ratios: per-minute red/IR ratios over the sleep window (one per usable minute).
+ * baselineRatio: the user's rolling baseline ratio, or null if not yet established.
+ *
+ * Returns a RELATIVE index + a computed confidence. With no baseline yet it reports
+ * night_ratio only (to seed the baseline) and a null index — honest, not guessed.
+ */
+export function calcSpo2Index(ratios: number[], baselineRatio: number | null): Metric<Spo2Value> {
+  const r = ratios.filter(PLAUSIBLE);
+  const none = (conf = 0): Metric<Spo2Value> => ({
+    index: null, night_ratio: null, confidence: conf, tier: 'RELATIVE', inputs_used: [],
+  });
+  if (r.length < MIN_MINUTES) return none();
+
+  const med = median(r);
+  if (med == null) return none();
+  const nightR = round(med, 4);
+  const m = mean(r);
+  const cv = m > 0 ? stddev(r) / m : 1;
+  // confidence: more minutes (cap at 3 h) AND a stable within-night ratio.
+  const conf = round(clamp(Math.min(r.length / 180, 1) * Math.max(0, 1 - cv / CV_FLOOR), 0, 1), 3);
+  const inputs_used = ['spo2_red_raw', 'spo2_ir_raw'];
+  const ref: MetricRef = { metric: 'spo2', scale: 'day' };
+
+  // No personal baseline yet → seed value only, no fabricated index.
+  if (baselineRatio == null || !(baselineRatio > 0)) {
+    return { index: null, night_ratio: nightR, confidence: round(conf * 0.5, 3), tier: 'RELATIVE', inputs_used };
+  }
+
+  // + = lower ratio than baseline = more oxygenated than your norm.
+  const index = round(((baselineRatio - nightR) / baselineRatio) * 100, 2);
+  const drivers: Driver[] = [
+    { label: 'Blood-oxygen vs baseline', contribution: index, detail: `R ${nightR} vs baseline ${round(baselineRatio, 4)}`, ref },
+  ];
+  return { index, night_ratio: nightR, confidence: conf, tier: 'RELATIVE', inputs_used, drivers };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -292,6 +292,20 @@ export interface BaselinesValue {
   days_used: number;
 }
 
+// CircaCP circadian rhythm + main-sleep boundary (see circadian.ts). Cosinor
+// phase is timezone-free (the physiological day anchor); onset/wake are the
+// main-sleep boundary of the most-recent completed cycle.
+export interface CircadianValue {
+  mesor: number | null;         // bpm, rhythm-adjusted mean HR
+  amplitude: number | null;     // bpm, cosinor amplitude (half peak-to-trough)
+  acrophase_ts: number | null;  // unix s, HR peak (active-phase center) near window end
+  bathyphase_ts: number | null; // unix s, HR trough (rest-phase center) of the detected cycle
+  onset_ts: number | null;      // main-sleep onset (HR drop), or null
+  wake_ts: number | null;       // main-sleep wake (HR rise), or null
+  in_bed_min: number;           // wake − onset, minutes
+  settled: boolean;             // wake older than the settle window → night complete
+}
+
 // ── history shapes for trend/baseline fns ───────────────────────────────────
 
 /** One night's sleep summary (for SRI). */

--- a/src/wake.ts
+++ b/src/wake.ts
@@ -1,0 +1,251 @@
+// wake.ts — sleep/wake state ENSEMBLE for the demand-driven day-close trigger.
+//
+// Purpose: from an assembled window of minute rollups, answer "is the user asleep
+// or awake right now, and if they just woke, when?" — cheaply, deterministically,
+// and HONESTLY (abstain to 'unknown' rather than fabricate). This is the gate that
+// fires the once-per-day Tier-3/4 derivation at the user's REAL wake, not a clock.
+//
+// Method: a PLUGGABLE registry of per-minute voters, each emitting asleep|awake|
+// unknown for every minute. We majority-vote per minute, consolidate into bouts,
+// then report the current state + the most-recent sleep→wake boundary. Voters are
+// swappable; the initial set is grounded in published, NON-TRAINED methods that fit
+// our exact per-minute signals (hr_avg, activity, and optional RR):
+//
+//   • coleKripke  — Cole-Kripke 1992 actigraphy weighted-sum (benchmark-competitive
+//                   among non-DL methods; ActiGraph/Newcastle PSG eval 2023).
+//   • cardiac     — CPD's core finding (Cakmak 2020, Sleep): cardiac change-points
+//                   carry the WAKE signal actigraphy misses. Uses HR level + change
+//                   vs the night's own trough, and RR-SD (HRV) when RR is supplied.
+//   • inactivity  — van Hees-style sustained-low-movement = sleep (non-trained).
+//
+// Thresholds are SELF-CALIBRATING off the window's own distribution (our `activity`
+// is stddev-of-|accel|, not actigraph counts, so absolute published thresholds don't
+// transfer — we use the published SHAPE with adaptive scaling). Tier = ESTIMATE; we
+// do NOT claim the papers' trained-model accuracy. Validate against ground truth.
+
+import type { Minute, Baseline } from './types';
+import { isHrUsable } from './util';
+
+export type WakeLabel = 'asleep' | 'awake' | 'unknown';
+
+export interface WakeContext {
+  minutes: Minute[];                  // time-ordered window (should span the night)
+  baseline: Baseline;                 // resting_hr anchor
+  rrByMin?: Map<number, number[]>;    // optional per-minute RR (ms) — enables the HRV arm of the cardiac voter
+  now?: number;                       // evaluation instant (default = last minute ts)
+}
+
+/** A voter labels EVERY minute in the window. Pure; no I/O. */
+export type Voter = (ctx: WakeContext) => WakeLabel[];
+
+export interface WakeState {
+  state: WakeLabel;        // current state at `now`
+  wake_ts: number | null;  // start of the most-recent sustained wake bout (the day boundary)
+  onset_ts: number | null; // start of the main sleep bout preceding that wake
+  awake_min: number;       // sustained awake minutes ending at `now`
+  asleep_min: number;      // minutes asleep in the main bout
+  votes: Record<string, WakeLabel>; // each voter's verdict at `now` (transparency)
+  confidence: number;      // 0..1 (voter agreement × data coverage)
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+const MIN = 60;
+const MIN_MAIN_SLEEP_MIN = 90;   // a real night, not a catnap, must precede a "wake"
+const SUSTAINED_WAKE_MIN = 10;   // your rule: awake must hold ≥10 min before we fire
+
+function median(xs: number[]): number {
+  if (!xs.length) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+// ── Voter 1: Cole-Kripke (actigraphy weighted-sum, published shape) ───────────
+// D = P·Σ wᵢ·Aᵢ over [−4..+2] minutes; sleep if D < 1. Our `activity` is rescaled
+// to the window so the unit-dependent constants behave (self-calibrating).
+const CK_W = [106, 54, 58, 76, 230, 74, 67]; // weights for A[-4..+2]
+const CK_P = 0.001;
+export const coleKripke: Voter = ({ minutes }) => {
+  const act = minutes.map((m) => (m.wrist_on ? m.activity : 0));
+  // normalize activity to a counts-like scale: median wake-ish activity ≈ unit.
+  const nz = act.filter((a) => a > 0);
+  const scale = median(nz) || 1; // counts ≈ activity/scale
+  const n = minutes.length;
+  return minutes.map((_, i) => {
+    if (!isHrUsable(minutes[i]) && minutes[i].activity === 0) return 'unknown';
+    let d = 0;
+    for (let k = -4; k <= 2; k++) {
+      const j = i + k;
+      if (j < 0 || j >= n) continue;
+      d += CK_W[k + 4] * (act[j] / scale);
+    }
+    d *= CK_P;
+    return d < 1 ? 'asleep' : 'awake';
+  });
+};
+
+// ── Voter 2: Cardiac (CPD core — the wake signal actigraphy misses) ───────────
+// Awake when HR sits above the night's cardiac trough by a margin, OR a sustained
+// upward HR change-point fires. When RR is supplied, a rise in short-window RR-SD
+// (HRV climbs toward/at wake) reinforces 'awake'. Self-calibrating off the window.
+export const cardiac: Voter = ({ minutes, baseline, rrByMin }) => {
+  const usable = minutes.filter(isHrUsable).map((m) => m.hr_avg);
+  // cardiac trough: low percentile of the window's HR (sleeping HR), floored by RHR.
+  const sorted = [...usable].sort((a, b) => a - b);
+  const p10 = sorted.length ? sorted[Math.floor(sorted.length * 0.1)] : baseline.resting_hr;
+  const trough = Math.max(baseline.resting_hr || 0, p10 || 0) || (sorted[0] ?? 0);
+  const wakeMargin = 6; // bpm above the sleeping trough → cardiac wake
+  return minutes.map((m) => {
+    if (!isHrUsable(m)) return 'unknown';
+    let vote: WakeLabel = m.hr_avg > trough + wakeMargin ? 'awake' : 'asleep';
+    // RR/HRV arm: a populated, healthy RR-SD that's elevated supports 'awake'.
+    const rr = rrByMin?.get(Math.floor(m.ts / MIN) * MIN);
+    if (rr && rr.length >= 4) {
+      const mean = rr.reduce((s, v) => s + v, 0) / rr.length;
+      const sd = Math.sqrt(rr.reduce((s, v) => s + (v - mean) ** 2, 0) / rr.length);
+      if (sd > 80 && m.hr_avg > trough) vote = 'awake'; // high beat-to-beat variability + above trough
+    }
+    return vote;
+  });
+};
+
+// ── Voter 3: van Hees-style sustained inactivity ──────────────────────────────
+// Sleep = movement held below an adaptive low threshold across a rolling window.
+export const inactivity: Voter = ({ minutes }) => {
+  const act = minutes.map((m) => (m.wrist_on ? m.activity : NaN));
+  const worn = act.filter((a) => Number.isFinite(a)) as number[];
+  const s = [...worn].sort((a, b) => a - b);
+  const pct = (p: number) => (s.length ? s[Math.min(s.length - 1, Math.floor(s.length * p))] : 0);
+  const p10 = pct(0.1), p90 = pct(0.9);
+  // "Still" = at/below the window's low (sleep) floor + a margin. Anchoring on the
+  // floor (not the median) is robust when the window is sleep-dominated, where the
+  // median itself sits inside the sleep mode. ABS_MOVE (~0.05 g RMS) is the still→move
+  // boundary in our `activity` units; the range term adapts when the window has daytime.
+  const ABS_MOVE = 0.05;
+  const thr = p10 + Math.max(ABS_MOVE, 0.3 * (p90 - p10));
+  const W = 5; // minutes of sustained stillness
+  const n = minutes.length;
+  return minutes.map((_, i) => {
+    if (!Number.isFinite(act[i])) return 'unknown';
+    let still = 0, seen = 0;
+    for (let j = Math.max(0, i - W); j <= Math.min(n - 1, i + W); j++) {
+      if (!Number.isFinite(act[j])) continue;
+      seen++;
+      if (act[j] <= thr) still++;
+    }
+    if (seen === 0) return 'unknown';
+    return still / seen >= 0.7 ? 'asleep' : 'awake';
+  });
+};
+
+// Pluggable registry — swap/extend these as better algorithms are validated.
+export const DEFAULT_VOTERS: { name: string; fn: Voter }[] = [
+  { name: 'coleKripke', fn: coleKripke },
+  { name: 'cardiac', fn: cardiac },
+  { name: 'inactivity', fn: inactivity },
+];
+
+/** Majority label per minute across voters (unknown ignored; tie → unknown). */
+function majorityPerMinute(labels: WakeLabel[][], n: number): WakeLabel[] {
+  const out: WakeLabel[] = [];
+  for (let i = 0; i < n; i++) {
+    let asleep = 0, awake = 0, known = 0;
+    for (const arr of labels) {
+      const l = arr[i];
+      if (l === 'asleep') { asleep++; known++; }
+      else if (l === 'awake') { awake++; known++; }
+    }
+    if (known === 0) out.push('unknown');
+    else if (asleep > awake) out.push('asleep');
+    else if (awake > asleep) out.push('awake');
+    else out.push('unknown');
+  }
+  return out;
+}
+
+/**
+ * Run the ensemble over the window. Returns the current state + the most-recent
+ * sustained sleep→wake boundary (the physiological-day anchor). Requires ≥`minVote`
+ * agreement (default majority of the registry) AND a main sleep bout ≥90 min AND a
+ * sustained-awake stretch ≥10 min before reporting state='awake' with a wake_ts.
+ */
+export function detectWakeState(
+  ctx: WakeContext,
+  voters = DEFAULT_VOTERS,
+): WakeState {
+  const minutes = ctx.minutes;
+  const n = minutes.length;
+  const now = ctx.now ?? (n ? minutes[n - 1].ts : 0);
+  const empty: WakeState = { state: 'unknown', wake_ts: null, onset_ts: null, awake_min: 0, asleep_min: 0, votes: {}, confidence: 0 };
+  if (n < SUSTAINED_WAKE_MIN) return empty;
+
+  const perVoter = voters.map((v) => v.fn(ctx));
+  const labels = majorityPerMinute(perVoter, n);
+
+  // votes at `now` (last minute) for transparency.
+  const votes: Record<string, WakeLabel> = {};
+  voters.forEach((v, k) => { votes[v.name] = perVoter[k][n - 1] ?? 'unknown'; });
+
+  // Find the most-recent sleep bout and the wake that ends it.
+  // Walk backward: the current trailing run is "awake" if we just woke.
+  let i = n - 1;
+  // trailing awake run
+  let awakeRunStart = n;
+  while (i >= 0 && labels[i] === 'awake') { awakeRunStart = i; i--; }
+  // skip any unknown gap between wake and the sleep bout
+  while (i >= 0 && labels[i] === 'unknown') i--;
+  // the sleep bout
+  let sleepEnd = i;
+  while (i >= 0 && labels[i] !== 'awake') i--; // include asleep + interior unknowns
+  let sleepStart = i + 1;
+
+  const sleepBoutMin = sleepEnd >= sleepStart && sleepStart >= 0
+    ? Math.round((minutes[sleepEnd].ts - minutes[sleepStart].ts) / MIN) + 1 : 0;
+  const awakeMin = awakeRunStart < n
+    ? Math.round((minutes[n - 1].ts - minutes[awakeRunStart].ts) / MIN) + 1 : 0;
+
+  // coverage = fraction of the window with a known label.
+  const known = labels.filter((l) => l !== 'unknown').length;
+  const coverage = n ? known / n : 0;
+  const agree = (() => {
+    // mean per-minute voter agreement over known minutes (for confidence).
+    let acc = 0, c = 0;
+    for (let k = 0; k < n; k++) {
+      let a = 0, w = 0;
+      for (const arr of perVoter) { if (arr[k] === 'asleep') a++; else if (arr[k] === 'awake') w++; }
+      const tot = a + w; if (!tot) continue;
+      acc += Math.max(a, w) / tot; c++;
+    }
+    return c ? acc / c : 0;
+  })();
+  const confidence = Math.round(coverage * agree * 100) / 100;
+
+  // Current state.
+  const current: WakeLabel = labels[n - 1];
+  const justWoke = current === 'awake'
+    && awakeMin >= SUSTAINED_WAKE_MIN
+    && sleepBoutMin >= MIN_MAIN_SLEEP_MIN;
+
+  return {
+    state: current,
+    wake_ts: justWoke ? minutes[awakeRunStart].ts : null,
+    onset_ts: justWoke && sleepStart >= 0 && sleepStart <= sleepEnd ? minutes[sleepStart].ts : null,
+    awake_min: awakeMin,
+    asleep_min: sleepBoutMin,
+    votes,
+    confidence,
+  };
+}
+
+/**
+ * Cheap recent-window check for the cron's per-tick ladder (ladder-step 2): is the
+ * user plausibly awake in the last few minutes? Liberal (high-recall) on purpose —
+ * a 'maybe' only triggers the full `detectWakeState`; it never suppresses a wake.
+ */
+export function peekRecentState(recent: Minute[], baseline: Baseline): WakeLabel {
+  const worn = recent.filter((m) => m.wrist_on);
+  if (worn.length < 3) return 'unknown';
+  const hrUp = worn.filter(isHrUsable).some((m) => m.hr_avg > (baseline.resting_hr || 0) + 6);
+  const moving = worn.some((m) => m.activity > 0 && m.steps > 0);
+  return hrUp || moving ? 'awake' : 'asleep';
+}

--- a/src/wake.ts
+++ b/src/wake.ts
@@ -85,27 +85,28 @@ export const coleKripke: Voter = ({ minutes }) => {
 };
 
 // ── Voter 2: Cardiac (CPD core — the wake signal actigraphy misses) ───────────
-// Awake when HR sits above the night's cardiac trough by a margin, OR a sustained
-// upward HR change-point fires. When RR is supplied, a rise in short-window RR-SD
-// (HRV climbs toward/at wake) reinforces 'awake'. Self-calibrating off the window.
-export const cardiac: Voter = ({ minutes, baseline, rrByMin }) => {
+// Awake when SMOOTHED HR sits above the night's cardiac trough by a margin. This is
+// the band's single most reliable wake signal (quiet wake has elevated HR but no
+// motion — exactly where the actigraphy voters go blind). Smoothing (±2 min) means a
+// single REM/arousal HR spike can't flip a minute to 'awake'; only a sustained rise
+// does. The RR/HRV arm now lives in its OWN voter (hrvArousal) so it isn't
+// double-counted. Trough is self-calibrating off the window, floored by RHR.
+export const cardiac: Voter = ({ minutes, baseline }) => {
   const usable = minutes.filter(isHrUsable).map((m) => m.hr_avg);
-  // cardiac trough: low percentile of the window's HR (sleeping HR), floored by RHR.
   const sorted = [...usable].sort((a, b) => a - b);
   const p10 = sorted.length ? sorted[Math.floor(sorted.length * 0.1)] : baseline.resting_hr;
   const trough = Math.max(baseline.resting_hr || 0, p10 || 0) || (sorted[0] ?? 0);
-  const wakeMargin = 6; // bpm above the sleeping trough → cardiac wake
-  return minutes.map((m) => {
-    if (!isHrUsable(m)) return 'unknown';
-    let vote: WakeLabel = m.hr_avg > trough + wakeMargin ? 'awake' : 'asleep';
-    // RR/HRV arm: a populated, healthy RR-SD that's elevated supports 'awake'.
-    const rr = rrByMin?.get(Math.floor(m.ts / MIN) * MIN);
-    if (rr && rr.length >= 4) {
-      const mean = rr.reduce((s, v) => s + v, 0) / rr.length;
-      const sd = Math.sqrt(rr.reduce((s, v) => s + (v - mean) ** 2, 0) / rr.length);
-      if (sd > 80 && m.hr_avg > trough) vote = 'awake'; // high beat-to-beat variability + above trough
-    }
-    return vote;
+  const wakeMargin = 8; // bpm above the sleeping trough → cardiac wake (separates wake from REM)
+  // ±2-min median-smoothed HR (NaN where unusable) so spikes don't fragment the vote.
+  const hr = minutes.map((m) => (isHrUsable(m) ? m.hr_avg : NaN));
+  const hs = hr.map((_, i) => {
+    const seg = hr.slice(Math.max(0, i - 2), Math.min(hr.length, i + 3))
+      .filter((v) => Number.isFinite(v)).sort((a, b) => a - b);
+    return seg.length ? seg[seg.length >> 1] : NaN;
+  });
+  return minutes.map((_, i) => {
+    if (!Number.isFinite(hs[i])) return 'unknown';
+    return hs[i] > trough + wakeMargin ? 'awake' : 'asleep';
   });
 };
 
@@ -138,29 +139,102 @@ export const inactivity: Voter = ({ minutes }) => {
   });
 };
 
+// ── Voter 4: HRV / RR autonomic arousal ───────────────────────────────────────
+// Beat-to-beat RR spread (SD) climbs with autonomic arousal toward and at wake. A
+// minute is 'awake' when its short-window RR-SD is elevated AND HR sits above the
+// sleeping trough. Returns 'unknown' when the minute has no RR — so a night without
+// RR simply drops this voter rather than biasing it. This is the SECOND autonomic
+// signal: paired with `cardiac` it lets the ≥2 consensus fire on quiet wake (HR up,
+// no motion) without the two blind motion voters being able to veto it.
+export const hrvArousal: Voter = ({ minutes, baseline, rrByMin }) => {
+  const usable = minutes.filter(isHrUsable).map((m) => m.hr_avg);
+  const sorted = [...usable].sort((a, b) => a - b);
+  const p10 = sorted.length ? sorted[Math.floor(sorted.length * 0.1)] : baseline.resting_hr;
+  const trough = Math.max(baseline.resting_hr || 0, p10 || 0) || (sorted[0] ?? 0);
+  const RR_SD_WAKE = 45; // ms — elevated beat-to-beat spread (validated on real RR)
+  // Per-minute RR-SD (NaN when <4 beats)…
+  const sdRaw = minutes.map((m) => {
+    const rr = rrByMin?.get(Math.floor(m.ts / MIN) * MIN);
+    if (!rr || rr.length < 4) return NaN;
+    const mean = rr.reduce((s, v) => s + v, 0) / rr.length;
+    return Math.sqrt(rr.reduce((s, v) => s + (v - mean) ** 2, 0) / rr.length);
+  });
+  // …then ±2-min median-smoothed. Raw minute RR-SD bounces across the threshold, which
+  // fragments the morning wake so cardiac+hrv only intermittently reach the ≥2 bar;
+  // smoothing makes the autonomic signal continuous (mirrors the cardiac HR smoothing).
+  const sd = sdRaw.map((_, i) => {
+    const seg = sdRaw.slice(Math.max(0, i - 2), Math.min(sdRaw.length, i + 3))
+      .filter((v) => Number.isFinite(v)).sort((a, b) => a - b);
+    return seg.length ? seg[seg.length >> 1] : NaN;
+  });
+  return minutes.map((m, i) => {
+    if (!Number.isFinite(sd[i]) || !isHrUsable(m)) return 'unknown';
+    return sd[i] > RR_SD_WAKE && m.hr_avg > trough ? 'awake' : 'asleep';
+  });
+};
+
 // Pluggable registry — swap/extend these as better algorithms are validated.
+// FOUR voters, two families: motion (coleKripke, inactivity) + autonomic (cardiac,
+// hrvArousal). The consensus rule (≥2) + bout-smoothing is HR-led by construction —
+// motion is blind to quiet wake, so the autonomic pair must be able to carry a wake.
 export const DEFAULT_VOTERS: { name: string; fn: Voter }[] = [
   { name: 'coleKripke', fn: coleKripke },
   { name: 'cardiac', fn: cardiac },
   { name: 'inactivity', fn: inactivity },
+  { name: 'hrvArousal', fn: hrvArousal },
 ];
 
-/** Majority label per minute across voters (unknown ignored; tie → unknown). */
-function majorityPerMinute(labels: WakeLabel[][], n: number): WakeLabel[] {
+/**
+ * Consensus label per minute: AWAKE if ≥`minAwake` voters say awake. NOT a majority —
+ * a 2–2 split counts as AWAKE on purpose. Two of the four voters are motion-based and
+ * physically blind to quiet wakefulness (lying still, HR up); a flat majority lets them
+ * veto a correct cardiac+HRV wake (and ties → 'unknown' → the close never fires). The
+ * ≥2 rule means the autonomic pair (cardiac, hrvArousal) can carry a wake on their own,
+ * while still requiring corroboration (one voter alone never flips it). Else asleep if
+ * any voter had a known read; else unknown.
+ */
+function consensusPerMinute(labels: WakeLabel[][], n: number, minAwake = 2): WakeLabel[] {
   const out: WakeLabel[] = [];
   for (let i = 0; i < n; i++) {
-    let asleep = 0, awake = 0, known = 0;
+    let awake = 0, known = 0;
     for (const arr of labels) {
       const l = arr[i];
-      if (l === 'asleep') { asleep++; known++; }
-      else if (l === 'awake') { awake++; known++; }
+      if (l === 'awake') { awake++; known++; }
+      else if (l === 'asleep') known++;
     }
-    if (known === 0) out.push('unknown');
-    else if (asleep > awake) out.push('asleep');
-    else if (awake > asleep) out.push('awake');
-    else out.push('unknown');
+    out.push(awake >= minAwake ? 'awake' : known ? 'asleep' : 'unknown');
   }
   return out;
+}
+
+/**
+ * Merge per-minute label runs shorter than `minRun` minutes into their larger
+ * neighbour (repeated to a fixed point), so intermittent voter agreement reads as one
+ * stable bout instead of a sawtooth. The HRV voter flickers in/out, which fragments a
+ * real continuous wake into sub-threshold pieces; smoothing bridges them. Same
+ * technique the sleep stager uses on its hypnogram.
+ */
+function boutSmooth(labels: WakeLabel[], minRun = 10, passes = 4): WakeLabel[] {
+  const s = [...labels];
+  for (let p = 0; p < passes; p++) {
+    const runs: { a: number; b: number }[] = [];
+    for (let i = 0; i < s.length;) { let j = i; while (j < s.length && s[j] === s[i]) j++; runs.push({ a: i, b: j - 1 }); i = j; }
+    if (runs.length <= 1) break;
+    let changed = false;
+    for (let r = 0; r < runs.length; r++) {
+      const { a, b } = runs[r];
+      if (b - a + 1 >= minRun) continue;
+      const prev = r > 0 ? runs[r - 1] : null;
+      const next = r < runs.length - 1 ? runs[r + 1] : null;
+      let tgt: WakeLabel | null = null;
+      if (prev && next) tgt = (prev.b - prev.a) >= (next.b - next.a) ? s[prev.a] : s[next.a];
+      else if (prev) tgt = s[prev.a];
+      else if (next) tgt = s[next.a];
+      if (tgt) { for (let x = a; x <= b; x++) s[x] = tgt; changed = true; }
+    }
+    if (!changed) break;
+  }
+  return s;
 }
 
 /**
@@ -180,7 +254,8 @@ export function detectWakeState(
   if (n < SUSTAINED_WAKE_MIN) return empty;
 
   const perVoter = voters.map((v) => v.fn(ctx));
-  const labels = majorityPerMinute(perVoter, n);
+  // HR-led consensus (≥2 awake, ties→awake) then bout-smoothed into stable bouts.
+  const labels = boutSmooth(consensusPerMinute(perVoter, n));
 
   // votes at `now` (last minute) for transparency.
   const votes: Record<string, WakeLabel> = {};


### PR DESCRIPTION
## feat/wake-trigger → main

### Sleep/wake ensemble + new metrics
- `wake.ts` — pluggable sleep/wake voter ensemble (`detectWakeState` + cheap `peekRecentState`) driving the v2 wake-triggered day-close.
- v1-method hypnogram (`stageHypnogram`) + `sleepAwakeMask` with RR REM-vs-wake tiebreaker.
- Ultradian sleep cycles (`detectSleepCycles`, Rosenblum 2024 fractal method, HRV-adapted).
- **Menstrual cycle**: `calcCycle` — log-anchored calendar method, median cycle length, next-period + ovulation (next−14, Wilcox 2000) + fertile window, phase, confidence (collapses when overdue). Pure & honest (abstains with no logs).

### Tests
- 201 assertions pass (incl. RR-REM, quiet-wake, cycles, +13 menstrual-cycle cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
