### PR TITLE
feat(sleep): forced-window staging + HR-led fallback

### DIFF
--- a/lib/src/onehz/sleep/advanced_stager.dart
+++ b/lib/src/onehz/sleep/advanced_stager.dart
@@ -283,6 +283,38 @@ class AdvancedSleepStager {
     return sessions;
   }
 
+  /// Stage a KNOWN in-bed window into a single [SleepSession] WITHOUT running
+  /// detection — for a manual / user-confirmed sleep window (no auto window was
+  /// found, or the user corrected it). Deliberately bypasses EVERY detection
+  /// gate (the 3 h minimum, daytime-center guard, HR confirmation, off-wrist
+  /// fraction): the window is asserted by the human, so we do not re-litigate
+  /// whether it is sleep — we only label the stages within it. Staging itself
+  /// runs through the SAME [_stageSession]/[_stageSessionV2] code the auto path
+  /// uses, so the single-source invariant holds (only the WINDOW boundary is
+  /// forced, never the staging math). Seconds with no data inside [startSec,
+  /// endSec) simply stay unstaged (wake) — honest about gaps, never fabricated.
+  static SleepSession stageWindow(
+    int startSec,
+    int endSec,
+    List<GravTs> gravity,
+    List<HrTs> hr, {
+    List<RrTs> rr = const [],
+    List<RespTs> resp = const [],
+    bool useV2 = false,
+  }) {
+    final stages = useV2
+        ? _stageSessionV2(startSec, endSec, gravity, hr, rr)
+        : _stageSession(startSec, endSec, gravity, hr, rr, resp);
+    return SleepSession(
+      start: startSec,
+      end: endSec,
+      efficiency: _efficiency(startSec, endSec, stages),
+      stages: stages,
+      restingHr: _sessionRestingHR(startSec, endSec, hr),
+      avgHrv: _sessionAvgHRV(startSec, endSec, rr),
+    );
+  }
+
   /// Convenience: the MAIN sleep (longest TST session) as a [Metric], with its
   /// AASM metrics + 4-class hypnogram. Absent when no qualifying sleep.
   static Metric<SleepSession> mainSleep(

--- a/lib/src/onehz/sleep/hr_fallback.dart
+++ b/lib/src/onehz/sleep/hr_fallback.dart
@@ -1,0 +1,137 @@
+// HR-LED FALLBACK sleep-window detector (Approach 2).
+//
+// The primary detector (van Hees, see segment.dart) is ACCELEROMETER-led: it
+// finds sleep from sustained wrist immobility. That fails for restless sleepers,
+// a loose band, or noisy/ gappy accel — exactly the "no sleep detected" nights.
+//
+// This fallback ignores motion and leans on the signal that is still good on
+// those nights: a sustained NOCTURNAL HR DIP toward the personal resting level.
+// It finds the longest run of low, valid HR (gap-aware, bridging brief arousals)
+// and returns it as a CANDIDATE in-bed window. It is deliberately conservative —
+// a wrong sleep window erodes trust more than a missing one — so it requires a
+// real, sustained dip of meaningful duration; otherwise it returns null.
+//
+// HONESTY: this only proposes a WINDOW. The caller stages it via
+// segmentSleep(forcedWindow: …) and surfaces the result as LOW confidence with a
+// "is this right?" prompt — never as a confirmed auto detection.
+
+import '../util.dart';
+
+/// A proposed in-bed window (epoch seconds). Returned by [hrLedSleepWindow].
+class HrLedWindow {
+  final int onsetSec;
+  final int offsetSec;
+
+  /// Threshold (bpm) the dip had to stay under, for transparency.
+  final double thresholdBpm;
+
+  const HrLedWindow(this.onsetSec, this.offsetSec, this.thresholdBpm);
+
+  int get durationSec => offsetSec - onsetSec;
+}
+
+/// Find a sleep window from a sustained nocturnal HR dip.
+///
+/// [hr1hz] 1 Hz HR (bpm; 0 / non-finite = off-skin), aligned 1:1 with [tsSec]
+/// (epoch seconds). [hrBaseline] optional daytime HR samples (bpm) — when given,
+/// the dip threshold is anchored to the user's own waking level; otherwise it
+/// falls back to the lower quartile of the night's own valid HR.
+///
+/// Returns the longest qualifying low-HR run (≥ [minDurationSec], brief
+/// arousals < [bridgeGapSec] bridged), or null when no convincing dip exists.
+HrLedWindow? hrLedSleepWindow(
+  List<double> hr1hz,
+  List<int> tsSec, {
+  List<double>? hrBaseline,
+  int minDurationSec = 2 * 3600,
+  int bridgeGapSec = 30 * 60,
+  double smoothSec = 300,
+}) {
+  final n = hr1hz.length < tsSec.length ? hr1hz.length : tsSec.length;
+  if (n < minDurationSec ~/ 2) return null;
+
+  // 1. Threshold: sleep HR sits meaningfully below the waking level. Prefer the
+  //    daytime baseline (×0.90 ≈ a 10% dip); else the night's own lower quartile.
+  final valid = <double>[for (var i = 0; i < n; i++) if (hr1hz[i].isFinite && hr1hz[i] > 0) hr1hz[i]];
+  if (valid.length < minDurationSec ~/ 4) return null;
+  double? threshold;
+  if (hrBaseline != null) {
+    final clean = hrBaseline.where((h) => h.isFinite && h > 0).toList();
+    final med = median(clean);
+    if (med != null) threshold = med * 0.90;
+  }
+  // No baseline: the lower-third of the window's own valid HR. This naturally
+  // self-bounds — on a flat record p30 sits at the flat level, so almost nothing
+  // reads "low" and we return null (no false dip). With a baseline we trust the
+  // ×0.90 waking-relative threshold and do NOT second-guess it against the
+  // window's own median (which is itself dragged down when the window is mostly
+  // night — that would push the threshold below the dip and miss it entirely).
+  threshold ??= percentile(valid, 30);
+  if (threshold == null) return null;
+
+  // 2. Smoothed HR (rolling median over ~[smoothSec] samples) so a single spike
+  //    or dropout doesn't fragment the dip. Off-skin (≤0) stays off-skin.
+  final win = smoothSec.round().clamp(1, n);
+  final smooth = _rollingMedianValidOnly(hr1hz, win);
+
+  // 3. "Low" mask: valid AND under threshold.
+  bool low(int i) => smooth[i] > 0 && smooth[i] < threshold!;
+
+  // 4. Longest low run, bridging brief arousals (gap-aware via real timestamps).
+  var bestStart = -1, bestEnd = -1, bestDur = 0;
+  var i = 0;
+  while (i < n) {
+    if (!low(i)) {
+      i++;
+      continue;
+    }
+    var j = i;
+    while (j < n) {
+      if (low(j)) {
+        j++;
+        continue;
+      }
+      // Look ahead: bridge a short non-low gap (arousal / brief wake) by TIME.
+      var k = j;
+      while (k < n && !low(k) && (tsSec[k] - tsSec[j]) < bridgeGapSec) {
+        k++;
+      }
+      if (k < n && low(k) && (tsSec[k] - tsSec[j]) < bridgeGapSec) {
+        j = k;
+      } else {
+        break;
+      }
+    }
+    final dur = tsSec[(j - 1).clamp(0, n - 1)] - tsSec[i];
+    if (dur > bestDur) {
+      bestDur = dur;
+      bestStart = i;
+      bestEnd = j;
+    }
+    i = j + 1;
+  }
+
+  if (bestStart < 0 || bestDur < minDurationSec) return null;
+  final onsetSec = tsSec[bestStart];
+  final offsetSec = tsSec[(bestEnd - 1).clamp(0, n - 1)] + 1;
+  if (offsetSec <= onsetSec) return null;
+  return HrLedWindow(onsetSec, offsetSec, threshold);
+}
+
+/// Rolling median over a centered window of [win] samples, treating ≤0 / NaN as
+/// missing (they are skipped, not counted as 0). Output ≤0 marks "still missing".
+List<double> _rollingMedianValidOnly(List<double> xs, int win) {
+  final n = xs.length;
+  final out = List<double>.filled(n, 0);
+  final half = win ~/ 2;
+  for (var i = 0; i < n; i++) {
+    final lo = (i - half).clamp(0, n);
+    final hi = (i + half + 1).clamp(0, n);
+    final buf = <double>[];
+    for (var k = lo; k < hi; k++) {
+      if (xs[k].isFinite && xs[k] > 0) buf.add(xs[k]);
+    }
+    out[i] = buf.isEmpty ? 0 : (median(buf) ?? 0);
+  }
+  return out;
+}

--- a/lib/src/onehz/sleep/segment.dart
+++ b/lib/src/onehz/sleep/segment.dart
@@ -156,13 +156,25 @@ SleepSegmentation segmentSleep(
   List<double> rrMs = const [],
   List<double> rrTsMs = const [],
   int? habitualMidsleepSec,
+  ({int onsetSec, int offsetSec})? forcedWindow,
 }) {
   final n = math.min(accel.length, hr1hz.length);
-  if (n < _minQualifyingSleepSec) return SleepSegmentation.absent;
+  // A forced window (manual entry / user confirmation, Approach 1) is asserted
+  // by the human, so it skips the 3 h sample-count gate the auto path enforces —
+  // a user may log a 2 h nap, and partial data inside the window is fine (those
+  // seconds just stay unstaged/wake). We still need SOME data to stage.
+  if (forcedWindow == null && n < _minQualifyingSleepSec) {
+    return SleepSegmentation.absent;
+  }
+  if (n == 0) return SleepSegmentation.absent;
 
   final trimmedAccel = accel.sublist(0, n);
   final trimmedHr = hr1hz.sublist(0, n);
-  final wm = vanHeesSleepWindow(trimmedAccel);
+  // van Hees only runs on the AUTO path; a forced window replaces it entirely.
+  final wm = forcedWindow == null
+      ? vanHeesSleepWindow(trimmedAccel)
+      : const Metric<SleepWindow>.absent(
+          tier: Tier.estimate, inputs_used: ['forced_window']);
   final fallbackWindow = wm.value;
 
   final tzOffsetSeconds = DateTime.fromMillisecondsSinceEpoch(
@@ -188,26 +200,47 @@ SleepSegmentation segmentSleep(
         RrTs((rrTsMs[i] / 1000.0).round(), rrMs[i])
   ];
 
-  final sessions = AdvancedSleepStager.detectSleep(
-    grav,
-    hr,
-    rr: rr,
-    tzOffsetSec: tzOffsetSeconds,
-  );
-  if (sessions.isEmpty) return SleepSegmentation.absent;
+  final _SleepGroup? chosen;
+  if (forcedWindow != null) {
+    final onsetSec = forcedWindow.onsetSec;
+    final offsetSec = forcedWindow.offsetSec;
+    if (offsetSec <= onsetSec) return SleepSegmentation.absent;
+    // Stage the user-asserted window directly — no detection, no gates.
+    final session =
+        AdvancedSleepStager.stageWindow(onsetSec, offsetSec, grav, hr, rr: rr);
+    chosen = _SleepGroup(
+      sessions: [session],
+      start: onsetSec,
+      end: offsetSec,
+      asleepMin: AdvancedSleepStager.hypnogramMetrics(session).tstS / 60.0,
+      inBedSec: offsetSec - onsetSec,
+    );
+  } else {
+    final sessions = AdvancedSleepStager.detectSleep(
+      grav,
+      hr,
+      rr: rr,
+      tzOffsetSec: tzOffsetSeconds,
+    );
+    if (sessions.isEmpty) return SleepSegmentation.absent;
 
-  final chosen = _pickMainSleepGroup(
-    _bridgeAdjacentSessions(sessions),
-    tzOffsetSeconds,
-    habitualMidsleepSec: habitualMidsleepSec,
-  );
+    chosen = _pickMainSleepGroup(
+      _bridgeAdjacentSessions(sessions),
+      tzOffsetSeconds,
+      habitualMidsleepSec: habitualMidsleepSec,
+    );
+  }
   if (chosen == null) return SleepSegmentation.absent;
 
   final tsSec = [for (final a in trimmedAccel) a.tsMs ~/ 1000];
   final onset = _lowerBoundInt(tsSec, chosen.start);
   final offset = _lowerBoundInt(tsSec, chosen.end);
   final inBed = chosen.end - chosen.start;
-  if (offset <= onset || inBed < _minQualifyingSleepSec) {
+  if (inBed <= 0) return SleepSegmentation.absent;
+  // The empty-index and 3 h in-bed floors are AUTO-path sanity gates; a forced
+  // window is the user's word — honor any positive-length window.
+  if (forcedWindow == null &&
+      (offset <= onset || inBed < _minQualifyingSleepSec)) {
     return SleepSegmentation.absent;
   }
 

--- a/lib/src/onehz/sleep/sleep.dart
+++ b/lib/src/onehz/sleep/sleep.dart
@@ -17,6 +17,7 @@
 
 export 'van_hees.dart';
 export 'segment.dart';
+export 'hr_fallback.dart';
 export 'advanced_stager.dart';
 export 'sri.dart';
 export 'accounting.dart';

--- a/test/onehz/hr_fallback_test.dart
+++ b/test/onehz/hr_fallback_test.dart
@@ -1,0 +1,69 @@
+import 'package:test/test.dart';
+import 'package:openstrap_analytics/onehz.dart';
+
+void main() {
+  group('hrLedSleepWindow (Approach 2 fallback)', () {
+    // Build a day: active morning (~72 bpm), a sustained night dip (~50 bpm),
+    // active tail. tsSec is contiguous 1 Hz from an arbitrary epoch.
+    ({List<double> hr, List<int> ts}) day(int dayH, int nightH, int tailH,
+        {double nightBpm = 50, List<int> arouseAt = const []}) {
+      final hr = <double>[];
+      final ts = <int>[];
+      const t0 = 1700000000;
+      var t = t0;
+      void seg(int secs, double bpm, {bool noise = false}) {
+        for (var i = 0; i < secs; i++) {
+          hr.add(bpm + (noise ? 6 * ((i % 7) - 3) : 0.0));
+          ts.add(t++);
+        }
+      }
+      seg(dayH * 3600, 72, noise: true);
+      final nightStart = hr.length;
+      seg(nightH * 3600, nightBpm);
+      for (final a in arouseAt) {
+        final idx = nightStart + a;
+        if (idx < hr.length) hr[idx] = 80; // brief arousal spike
+      }
+      seg(tailH * 3600, 72, noise: true);
+      return (hr: hr, ts: ts);
+    }
+
+    test('sustained night dip → finds a window of ~the dip length', () {
+      final d = day(2, 7, 1);
+      final w = hrLedSleepWindow(d.hr, d.ts,
+          hrBaseline: List<double>.filled(120, 72));
+      expect(w, isNotNull);
+      // ~7h dip (bridge tolerates the edges); well over the 2h floor.
+      expect(w!.durationSec, greaterThan(6 * 3600));
+      expect(w.durationSec, lessThan(8 * 3600));
+      expect(w.thresholdBpm, lessThan(72));
+    });
+
+    test('brief arousals do not fragment the dip', () {
+      final d = day(2, 7, 1, arouseAt: [2 * 3600, 4 * 3600, 5 * 3600 + 1800]);
+      final w = hrLedSleepWindow(d.hr, d.ts,
+          hrBaseline: List<double>.filled(120, 72));
+      expect(w, isNotNull);
+      expect(w!.durationSec, greaterThan(6 * 3600));
+    });
+
+    test('no dip (flat elevated HR all day) → null', () {
+      final hr = <double>[];
+      final ts = <int>[];
+      const t0 = 1700000000;
+      for (var i = 0; i < 6 * 3600; i++) {
+        hr.add(74 + (i % 5).toDouble());
+        ts.add(t0 + i);
+      }
+      final w = hrLedSleepWindow(hr, ts, hrBaseline: List<double>.filled(60, 75));
+      expect(w, isNull);
+    });
+
+    test('dip too short (<2h) → null', () {
+      final d = day(2, 1, 1); // only a 1h dip
+      final w = hrLedSleepWindow(d.hr, d.ts,
+          hrBaseline: List<double>.filled(120, 72));
+      expect(w, isNull);
+    });
+  });
+}

--- a/test/onehz/sleep_test.dart
+++ b/test/onehz/sleep_test.dart
@@ -323,6 +323,49 @@ void main() {
       expect(s.confidence, 0);
     });
 
+    test('(c5) forced window honors a user window the auto path rejects (<3h) '
+        'and stages within it (single-source)', () {
+      // A 2h still night sits BELOW the 3h auto floor → auto returns absent.
+      final accel = _accel(2, 2, 1);
+      final hr = _hr(2, 2, 1);
+      expect(segmentSleep(accel, hr).present, isFalse, reason: 'auto rejects <3h');
+
+      // The user asserts sleep across the still block. tsMs == index*1000, so
+      // epoch-seconds == index; the night runs [7200, 14400).
+      final s = segmentSleep(accel, hr,
+          forcedWindow: (onsetSec: 7200, offsetSec: 14400));
+      expect(s.present, isTrue);
+      expect(s.window, isNotNull);
+      // The in-bed window is EXACTLY the user's stated duration.
+      expect(s.inBedSec, 14400 - 7200);
+      // Staging ran over the still + low-HR block → mostly asleep.
+      expect(s.tstSec!, greaterThan((0.5 * s.inBedSec!).round()));
+      // Single-source consistency holds for a forced window too.
+      expect(s.stages.length, s.inBedSec);
+      expect(s.nremSec! + s.remSec! + s.wakeSec!, s.inBedSec);
+      expect(s.lightSec! + s.deepSec!, s.nremSec);
+    });
+
+    test('(c6) forced window bypasses the no-auto-window absent case', () {
+      // All-active capture (auto finds no inactivity block at all).
+      final rnd = math.Random(7);
+      final accel = <AccelSample>[];
+      final hr = <double>[];
+      for (var i = 0; i < 4 * 3600; i++) {
+        accel.add(AccelSample(i * 1000.0, rnd.nextDouble() * 2 - 1,
+            rnd.nextDouble() * 2 - 1, rnd.nextDouble() * 2 - 1));
+        hr.add(75 + rnd.nextDouble() * 10);
+      }
+      expect(segmentSleep(accel, hr).present, isFalse);
+      // The window is honored even though nothing looked like sleep; TST may be
+      // ~0 (honest), but the in-bed window is recorded.
+      final s = segmentSleep(accel, hr,
+          forcedWindow: (onsetSec: 3600, offsetSec: 3 * 3600));
+      expect(s.present, isTrue);
+      expect(s.inBedSec, 2 * 3600);
+      expect(s.stages.length, s.inBedSec);
+    });
+
     test('(c3) overnight main sleep beats a longer daytime nap', () {
       final accel = <AccelSample>[];
       final hr = <double>[];


### PR DESCRIPTION
Adds the analytics foundation for manual sleep entry + a fallback detector (consumed by the edge app's sleep-rescue feature).

## What
- `segmentSleep(forcedWindow:)` + `AdvancedSleepStager.stageWindow()` — stage a user-asserted in-bed window using the **same** staging code as the auto path (single-source invariant intact); only the detection gates (3 h floor, daytime guard, HR-confirm, off-wrist) are bypassed.
- `hrLedSleepWindow()` — when accel-led van Hees detection finds nothing (restless sleeper / loose band / gappy accel), propose the longest sustained nocturnal HR dip. Conservative, gap-aware, bridges brief arousals. Low-confidence; the caller stages it and prompts for confirmation.

## Tests
`dart test` → **231 passing** (forced-window cases + 4 new fallback cases). No change to existing auto-path outputs (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)