### PR TITLE
recover: restore pre-rewind local-first work

### DIFF
--- a/lib/src/onehz/workout/auto_detect.dart
+++ b/lib/src/onehz/workout/auto_detect.dart
@@ -74,8 +74,27 @@ class MotionPoint {
 class AutoWorkoutDetector {
   // ── Constants ─────────────────────────────────────────────────────────────
 
-  /// Elevated gate: bpm ≥ restingHR + this margin counts as "working".
-  static const int elevatedMarginBPM = 30;
+  /// Minimum elevated-gate margin (bpm above resting). A safety floor for the
+  /// %HRR gate below when HRmax is low/unknown — the real threshold is [hrrFloor].
+  static const int elevatedMarginBPM = 40;
+
+  /// PRIMARY gate: a bout must sit at ≥ this fraction of heart-rate RESERVE
+  /// (HRmax − RHR), not just a few bpm above rest. Calibrated on a full week of a
+  /// sedentary user's data (zero real workouts): a fixed RHR+30 margin (≈90 bpm)
+  /// flagged 30 windows; 0.45·HRR (~117 bpm at RHR 57 / HRmax 190) rejects
+  /// ordinary daytime and even a 3 h steady-state evening elevation, leaving only
+  /// short genuinely-cardio bouts (avg ≥ ~120 bpm) — which is exactly what a "did
+  /// you work out?" prompt should ask about.
+  static const double hrrFloorFraction = 0.45;
+
+  /// HRmax fallback when the caller passes none (age-predicted is preferred).
+  static const int defaultMaxHR = 190;
+
+  /// A suggested WORKOUT is time-bounded. A sustained elevation longer than this
+  /// (observed: ~3 h of steady 131 bpm from an active evening) is lifestyle
+  /// activity, not a workout — don't suggest it. Endurance sessions beyond this
+  /// are better logged manually than auto-prompted.
+  static const int maxWorkoutMin = 120;
 
   /// A candidate must hold the gate for a contiguous span ≥ this (12 min).
   static const double minSustainedMin = 12.0;
@@ -87,8 +106,12 @@ class AutoWorkoutDetector {
   static const int mergeGapS = 5 * 60;
 
   /// When a motion series is supplied, the window's mean per-second motion
-  /// intensity must be ≥ this to qualify. Ignored in HR-only mode.
-  static const double motionConfirmMean = 0.05;
+  /// intensity (L2 gravity-vector change/s, in g) must be ≥ this to qualify.
+  /// 0.05 was far too low — desk fidgeting/typing/gesturing while seated averages
+  /// above it, so an elevated resting HR alone got confirmed as a "workout". Real
+  /// ambulatory exercise (walking/running/lifting) sustains well above 0.15.
+  /// Ignored in HR-only mode.
+  static const double motionConfirmMean = 0.15;
 
   /// Resting-HR fallback when the caller has no nightly RHR.
   static const int defaultRestingHR = 60;
@@ -136,6 +159,7 @@ class AutoWorkoutDetector {
     required List<int> hrTs,
     required List<int> hrBpm,
     int? restingBpm,
+    int? maxBpm,
     List<MotionPoint>? motion,
     List<SavedWorkoutSpan> savedSpans = const [],
     SportClassifier classify = defaultSportClassifier,
@@ -147,7 +171,11 @@ class AutoWorkoutDetector {
     final ts = [for (final i in order) hrTs[i]];
     final bpm = [for (final i in order) hrBpm[i]];
 
-    final floor = (restingBpm ?? defaultRestingHR) + elevatedMarginBPM;
+    // %HRR floor (primary), never below the RHR+margin safety floor.
+    final rhr = restingBpm ?? defaultRestingHR;
+    final hrMax = maxBpm ?? defaultMaxHR;
+    final hrrFloor = (rhr + hrrFloorFraction * (hrMax - rhr)).round();
+    final floor = math.max(rhr + elevatedMarginBPM, hrrFloor);
 
     // --- 1+2+3: grow sustained spans tolerating brief dips ---
     final spans = <List<int>>[]; // [start, end]
@@ -201,6 +229,10 @@ class AutoWorkoutDetector {
     for (final span in merged) {
       final start = span[0], end = span[1];
 
+      // A workout is time-bounded — a multi-hour sustained elevation is lifestyle
+      // activity, not a workout to suggest.
+      if ((end - start) > maxWorkoutMin * 60) continue;
+
       // 6: never re-suggest a window overlapping a saved workout.
       if (savedSpans.any((s) => _overlaps(start, end, s.startSec, s.endSec))) {
         continue;
@@ -212,6 +244,13 @@ class AutoWorkoutDetector {
         if (ts[k] >= start && ts[k] <= end) winBpm.add(bpm[k]);
       }
       if (winBpm.isEmpty) continue;
+
+      // The WHOLE window must be genuinely elevated, not just brief floor
+      // crossings that dip-bridging stitched together — require the mean HR to
+      // clear the floor too. (A sedentary afternoon oscillating around the gate
+      // averaged below it; a real bout averages well above.)
+      final winMean = winBpm.reduce((a, b) => a + b) / winBpm.length;
+      if (winMean < floor) continue;
 
       // 5: motion confirmation when a continuous motion series was supplied.
       double? meanMotion;
@@ -273,6 +312,7 @@ Metric<List<DetectedWorkout>> autoDetectWorkouts({
   required List<int> hrTs,
   required List<int> hrBpm,
   int? restingBpm,
+  int? maxBpm,
   List<MotionPoint>? motion,
   List<SavedWorkoutSpan> savedSpans = const [],
   SportClassifier classify = defaultSportClassifier,
@@ -281,6 +321,7 @@ Metric<List<DetectedWorkout>> autoDetectWorkouts({
     hrTs: hrTs,
     hrBpm: hrBpm,
     restingBpm: restingBpm,
+    maxBpm: maxBpm,
     motion: motion,
     savedSpans: savedSpans,
     classify: classify,

--- a/test/onehz/coaching_test.dart
+++ b/test/onehz/coaching_test.dart
@@ -1,5 +1,5 @@
 // Coaching surface — synthetic known-answer tests, incl. a regression for the
-// physiological-age oversleep bug.
+// physiological-age oversleep bug. Covers PR #11's untested coaching API.
 import 'package:test/test.dart';
 import 'package:openstrap_analytics/src/onehz/types.dart';
 import 'package:openstrap_analytics/src/onehz/human/coaching.dart';
@@ -14,9 +14,40 @@ void main() {
         napCreditSec: 0,
       );
       expect(m.present, isTrue);
+      expect(m.tier, Tier.estimate);
+      expect(m.confidence, closeTo(0.6, 1e-9));
       expect(m.value!.needSec, closeTo(28800 + 2700, 1));
     });
-    test('clamps to the 6–11 h band', () {
+
+    test('mid case: baseline + debt + partial strain bonus − nap credit', () {
+      // strain 10.5 → bonus = (10.5/21)*2700 = 1350 s.
+      // 28800 + 3600 + 1350 − 1800 = 31950, inside the [6h,11h] band.
+      final m = sleepNeed(
+        baselineNeedSec: 28800,
+        sleepDebtSec: 3600,
+        dayStrain: 10.5,
+        napCreditSec: 1800,
+      );
+      expect(m.value!.needSec, closeTo(31950, 1e-6));
+    });
+
+    test('nap credit is subtracted', () {
+      final base = sleepNeed(
+        baselineNeedSec: 28800,
+        sleepDebtSec: 0,
+        dayStrain: 0,
+        napCreditSec: 0,
+      ).value!.needSec;
+      final withNap = sleepNeed(
+        baselineNeedSec: 28800,
+        sleepDebtSec: 0,
+        dayStrain: 0,
+        napCreditSec: 1800,
+      ).value!.needSec;
+      expect(withNap, closeTo(base - 1800, 1e-6));
+    });
+
+    test('clamps to the 11 h ceiling', () {
       final m = sleepNeed(
         baselineNeedSec: 999999,
         sleepDebtSec: 0,
@@ -25,34 +56,192 @@ void main() {
       );
       expect(m.value!.needSec, 11 * 3600.0);
     });
+
+    test('clamps to the 6 h floor (huge nap credit cannot go below 6h)', () {
+      final m = sleepNeed(
+        baselineNeedSec: 28800,
+        sleepDebtSec: 0,
+        dayStrain: 0,
+        napCreditSec: 999999,
+      );
+      expect(m.value!.needSec, 6 * 3600.0);
+    });
+  });
+
+  group('sleepPerformance', () {
+    test('exact need → 100%', () {
+      final m = sleepPerformance(28800, 28800);
+      expect(m.present, isTrue);
+      expect(m.tier, Tier.estimate);
+      expect(m.confidence, closeTo(0.7, 1e-9));
+      expect(m.value!.pct, closeTo(100.0, 1e-9));
+    });
+
+    test('half of need → 50%', () {
+      expect(sleepPerformance(14400, 28800).value!.pct, closeTo(50.0, 1e-9));
+    });
+
+    test('over-need caps at 100%', () {
+      expect(sleepPerformance(40000, 28800).value!.pct, closeTo(100.0, 1e-9));
+    });
+
+    test('zero sleep → 0%', () {
+      expect(sleepPerformance(0, 28800).value!.pct, closeTo(0.0, 1e-9));
+    });
+
+    test('non-positive need → absent (no divide-by-zero)', () {
+      expect(sleepPerformance(28800, 0).present, isFalse);
+      expect(sleepPerformance(28800, -1).present, isFalse);
+    });
+  });
+
+  group('recommendedBedtime', () {
+    test('backward math from wake time, efficiency-adjusted time-in-bed', () {
+      // need 8h=28800s, eff 90%→0.90, inBed=32000s=533.333min.
+      // wake 07:00 = 420 min. bed = (420 − 533.333) mod 1440 → 1326.667.
+      final m = recommendedBedtime(
+        needSec: 28800,
+        typicalWakeMinOfDay: 420,
+        typicalEfficiencyPct: 90,
+      );
+      expect(m.present, isTrue);
+      expect(m.tier, Tier.estimate);
+      expect(m.value!.bedtimeMinOfDay, closeTo(1326.6667, 1e-3));
+    });
+
+    test('efficiency is clamped to [0.75, 0.99]', () {
+      // A wild 200% efficiency is clamped to 0.99, not >1.
+      final m = recommendedBedtime(
+        needSec: 28800,
+        typicalWakeMinOfDay: 600,
+        typicalEfficiencyPct: 200,
+      );
+      // inBed = 28800/0.99 = 29090.9s = 484.848 min; bed = 600 − 484.848 = 115.152.
+      expect(m.value!.bedtimeMinOfDay, closeTo(115.1515, 1e-3));
+    });
+
+    test('minute-of-day never goes negative (wraparound to [0,1440))', () {
+      final m = recommendedBedtime(
+        needSec: 28800,
+        typicalWakeMinOfDay: 60, // 01:00 wake → bed the previous "day"
+        typicalEfficiencyPct: 90,
+      );
+      expect(m.value!.bedtimeMinOfDay, greaterThanOrEqualTo(0.0));
+      expect(m.value!.bedtimeMinOfDay, lessThan(1440.0));
+    });
+  });
+
+  group('recommendedWake', () {
+    test('90-minute cycle-aligned wake from bedtime', () {
+      // bed 23:00 = 1380, need 7.5h=27000s=450min → round(450/90)=5 cycles.
+      // wake = (1380 + 5*90) mod 1440 = 1830 mod 1440 = 390 = 06:30.
+      final m = recommendedWake(bedtimeMinOfDay: 1380, needSec: 27000);
+      expect(m.present, isTrue);
+      expect(m.tier, Tier.estimate);
+      expect(m.confidence, closeTo(0.55, 1e-9));
+      expect(m.value!.wakeMinOfDay, closeTo(390.0, 1e-9));
+    });
+
+    test('cycles floor at 1 for tiny need', () {
+      // need 30 min → round(30/90)=0 → max(1,0)=1 cycle = 90 min.
+      final m = recommendedWake(bedtimeMinOfDay: 100, needSec: 1800);
+      expect(m.value!.wakeMinOfDay, closeTo(190.0, 1e-9));
+    });
+
+    test('wraps around midnight into [0,1440)', () {
+      // bed 23:30=1410, need ~7.5h → 5 cycles=450 → 1860 mod 1440 = 420.
+      final m = recommendedWake(bedtimeMinOfDay: 1410, needSec: 27000);
+      expect(m.value!.wakeMinOfDay, closeTo(420.0, 1e-9));
+      expect(m.value!.wakeMinOfDay, lessThan(1440.0));
+    });
   });
 
   group('strainTarget', () {
     test('null recovery → absent', () {
-      final m = strainTarget(
-          recovery0to100: null, ctl: null, atl: null, tsb: null);
+      final m =
+          strainTarget(recovery0to100: null, ctl: null, atl: null, tsb: null);
       expect(m.present, isFalse);
     });
-    test('high recovery → push band', () {
-      final m = strainTarget(
-          recovery0to100: 90, ctl: null, atl: null, tsb: null);
-      expect(m.value!.band, 'push');
+
+    test('recovery bands: recover / ease / maintain / push', () {
+      expect(
+          strainTarget(recovery0to100: 20, ctl: null, atl: null, tsb: null)
+              .value!
+              .band,
+          'recover');
+      expect(
+          strainTarget(recovery0to100: 50, ctl: null, atl: null, tsb: null)
+              .value!
+              .band,
+          'ease');
+      expect(
+          strainTarget(recovery0to100: 70, ctl: null, atl: null, tsb: null)
+              .value!
+              .band,
+          'maintain');
+      expect(
+          strainTarget(recovery0to100: 90, ctl: null, atl: null, tsb: null)
+              .value!
+              .band,
+          'push');
     });
-    test('low recovery → recover band', () {
-      final m = strainTarget(
-          recovery0to100: 20, ctl: null, atl: null, tsb: null);
-      expect(m.value!.band, 'recover');
+
+    test('maintain band base window is [10,15]', () {
+      final m =
+          strainTarget(recovery0to100: 70, ctl: null, atl: null, tsb: null);
+      expect(m.value!.targetMin, closeTo(10, 1e-9));
+      expect(m.value!.targetMax, closeTo(15, 1e-9));
+      expect(m.tier, Tier.estimate);
+      expect(m.confidence, closeTo(0.6, 1e-9));
+    });
+
+    test('high fatigue (atl−ctl>10) lowers the window', () {
+      // maintain base [10,15]; fatigue = 30−10 = 20 (>10) → lo−1, hi−2 → [9,13].
+      final m = strainTarget(recovery0to100: 70, ctl: 10, atl: 30, tsb: null);
+      expect(m.value!.targetMin, closeTo(9, 1e-9));
+      expect(m.value!.targetMax, closeTo(13, 1e-9));
+    });
+
+    test('positive freshness (tsb>5) raises the ceiling', () {
+      // maintain base [10,15]; low fatigue so tsb branch applies → hi+1 → [10,16].
+      final m = strainTarget(recovery0to100: 70, ctl: 20, atl: 20, tsb: 8);
+      expect(m.value!.targetMin, closeTo(10, 1e-9));
+      expect(m.value!.targetMax, closeTo(16, 1e-9));
+    });
+
+    test('targets stay within [0,21] and hi > lo', () {
+      final m = strainTarget(recovery0to100: 90, ctl: null, atl: null, tsb: 99);
+      expect(m.value!.targetMin, greaterThanOrEqualTo(0.0));
+      expect(m.value!.targetMax, lessThanOrEqualTo(21.0));
+      expect(m.value!.targetMax, greaterThan(m.value!.targetMin));
     });
   });
 
   group('vo2maxEstimate', () {
-    test('Uth ratio; absent when maxHr <= restingHr', () {
-      final ok = vo2maxEstimate(
-          restingHr: 50, maxHr: 190, sex: Sex.male, age: 30);
-      expect(ok.value!, closeTo(15.3 * 190 / 50, 1e-6));
-      final bad = vo2maxEstimate(
-          restingHr: 190, maxHr: 180, sex: Sex.male, age: 30);
-      expect(bad.present, isFalse);
+    test('Uth ratio 15.3×maxHr/restingHr on a known value', () {
+      final m = vo2maxEstimate(restingHr: 50, maxHr: 190, sex: Sex.male, age: 30);
+      expect(m.present, isTrue);
+      expect(m.tier, Tier.estimate);
+      expect(m.confidence, closeTo(0.45, 1e-9));
+      expect(m.value!, closeTo(15.3 * 190 / 50, 1e-6)); // 58.14
+    });
+
+    test('absent when maxHr <= restingHr (no divide-by-invalid)', () {
+      expect(
+          vo2maxEstimate(restingHr: 190, maxHr: 180, sex: Sex.male, age: 30)
+              .present,
+          isFalse);
+    });
+
+    test('absent on null restingHr / null maxHr (no divide-by-zero)', () {
+      expect(
+          vo2maxEstimate(restingHr: null, maxHr: 190, sex: Sex.male, age: 30)
+              .present,
+          isFalse);
+      expect(
+          vo2maxEstimate(restingHr: 50, maxHr: null, sex: Sex.male, age: 30)
+              .present,
+          isFalse);
     });
   });
 
@@ -69,16 +258,160 @@ void main() {
         ).value!;
 
     test('oversleep does NOT make you younger', () {
-      expect(run(9.0).physioAge, greaterThanOrEqualTo(30.0));
+      expect(run(10.0).physioAge, greaterThan(30.0));
     });
     test('undersleep ages you', () {
-      expect(run(6.0).physioAge, greaterThan(30.0));
+      expect(run(5.0).physioAge, greaterThan(30.0));
     });
     test('optimal ~7.5h is neutral', () {
       expect(run(7.5).physioAge, closeTo(30.0, 0.01));
     });
-    test('under and over by the same amount age you equally', () {
-      expect(run(6.0).physioAge, closeTo(run(9.0).physioAge, 1e-9));
+    test('symmetry: 5h and 10h age you by the same amount', () {
+      // Both are 2.5h from the 7.5h optimum → identical penalty.
+      expect(run(5.0).physioAge, closeTo(run(10.0).physioAge, 1e-9));
+    });
+
+    test('baseline case: better-than-average biomarkers lower physio age', () {
+      final m = physiologicalAge(
+        chronologicalAge: 40,
+        sex: Sex.male,
+        vo2max: 50, // above 35 → subtracts
+        restingHr: 48, // below 60 → subtracts
+        rmssd: 60, // above 35 → subtracts
+        sleepDurationH: 7.5, // optimal → neutral
+        sleepEfficiency: 94, // above 88 → subtracts
+        dailySteps: 12000, // above 7000 → subtracts
+      );
+      expect(m.present, isTrue);
+      expect(m.tier, Tier.estimate);
+      expect(m.value!.physioAge, lessThan(40.0));
+      expect(m.value!.deltaYears, lessThan(0.0));
+      expect(m.value!.deltaYears,
+          closeTo(m.value!.physioAge - 40.0, 1e-9));
+    });
+
+    test('physio age is clamped to [18,95]', () {
+      final young = physiologicalAge(
+        chronologicalAge: 18,
+        sex: Sex.female,
+        vo2max: 80,
+        restingHr: 40,
+        rmssd: 120,
+        sleepDurationH: 7.5,
+        sleepEfficiency: 99,
+        dailySteps: 20000,
+      );
+      expect(young.value!.physioAge, greaterThanOrEqualTo(18.0));
+      final old = physiologicalAge(
+        chronologicalAge: 95,
+        sex: Sex.male,
+        vo2max: 10,
+        restingHr: 100,
+        rmssd: 5,
+        sleepDurationH: 3,
+        sleepEfficiency: 60,
+        dailySteps: 0,
+      );
+      expect(old.value!.physioAge, lessThanOrEqualTo(95.0));
+    });
+  });
+
+  group('journalCorrelations', () {
+    test('insufficient sample (<2 per side) is gated as insufficient', () {
+      // Only one tagged day for "coffee" → cannot compare.
+      final journal = <JournalDay>[
+        const JournalDay('d0', {'coffee'}),
+        const JournalDay('d1', {}),
+        const JournalDay('d2', {}),
+      ];
+      final dates = ['d0', 'd1', 'd2'];
+      final outcomes = <String, List<double?>>{
+        'recovery': [60, 62, 64],
+      };
+      final out = journalCorrelations(
+          journal: journal, dates: dates, outcomes: outcomes);
+      final coffee = out.firstWhere((c) => c.tag == 'coffee');
+      final eff = coffee.effects.single;
+      expect(eff.insufficient, isTrue);
+      expect(eff.meaningful, isFalse);
+      expect(eff.nTagged, 1);
+      expect(eff.higherSide, 'neither');
+    });
+
+    test('clear positive correlation is detected and marked meaningful', () {
+      // "alcohol" days have clearly lower recovery than untagged days.
+      final journal = <JournalDay>[
+        const JournalDay('d0', {'alcohol'}),
+        const JournalDay('d1', {'alcohol'}),
+        const JournalDay('d2', {}),
+        const JournalDay('d3', {}),
+      ];
+      final dates = ['d0', 'd1', 'd2', 'd3'];
+      final outcomes = <String, List<double?>>{
+        'recovery': [40, 42, 80, 82], // tagged mean 41, untagged mean 81
+      };
+      final out = journalCorrelations(
+          journal: journal, dates: dates, outcomes: outcomes);
+      final eff =
+          out.firstWhere((c) => c.tag == 'alcohol').effects.single;
+      expect(eff.insufficient, isFalse);
+      expect(eff.meaningful, isTrue);
+      expect(eff.delta, closeTo(41 - 81, 1e-9)); // −40
+      expect(eff.higherSide, 'untagged'); // untagged (non-alcohol) recovers more
+      expect(eff.nTagged, 2);
+      expect(eff.nUntagged, 2);
+      expect(eff.pctChange, isNotNull);
+      expect(eff.pctChange!.abs(), greaterThanOrEqualTo(3.0));
+    });
+
+    test('nulls are dropped from both sides before comparing', () {
+      final journal = <JournalDay>[
+        const JournalDay('d0', {'x'}),
+        const JournalDay('d1', {'x'}),
+        const JournalDay('d2', {}),
+        const JournalDay('d3', {}),
+      ];
+      final dates = ['d0', 'd1', 'd2', 'd3'];
+      final outcomes = <String, List<double?>>{
+        'hrv': [50, null, 60, 60], // tagged has only 1 valid → insufficient
+      };
+      final out = journalCorrelations(
+          journal: journal, dates: dates, outcomes: outcomes);
+      final eff = out.firstWhere((c) => c.tag == 'x').effects.single;
+      expect(eff.nTagged, 1);
+      expect(eff.insufficient, isTrue);
+    });
+
+    test('empty journal yields no correlations', () {
+      final out = journalCorrelations(
+        journal: const [],
+        dates: const ['d0', 'd1'],
+        outcomes: const {
+          'recovery': [50, 60]
+        },
+      );
+      expect(out, isEmpty);
+    });
+  });
+
+  group('detectNaps (honest stub)', () {
+    test('returns an empty nap list with zero confidence — no fabrication', () {
+      final m = detectNaps(const <AccelSample>[], const <double>[]);
+      expect(m.value, isNotNull); // an (empty) list, not a null
+      expect(m.value, isEmpty);
+      expect(m.confidence, 0);
+      expect(m.tier, Tier.estimate);
+      expect(m.note, contains('nap detection unavailable'));
+    });
+
+    test('still empty even when handed plausible sleep-like input', () {
+      final accel = <AccelSample>[
+        for (var i = 0; i < 100; i++) AccelSample(i * 1000.0, 0, 0, 1),
+      ];
+      final hr = <double>[for (var i = 0; i < 100; i++) 52.0];
+      final m = detectNaps(accel, hr,
+          mainSleep: const SleepWindowSpan(0, 30000));
+      expect(m.value, isEmpty);
     });
   });
 }

--- a/test/onehz/workout_test.dart
+++ b/test/onehz/workout_test.dart
@@ -40,7 +40,7 @@ void main() {
       );
       expect(out, hasLength(1));
       final w = out.first;
-      // floor = 60+30 = 90; work span 140 bpm. window = [600, 1499].
+      // floor = max(60+40, 60+.45*(190-60)) = 119; work span 140 bpm. window = [600, 1499].
       expect(w.startSec, 600);
       expect(w.endSec, 1499);
       expect(w.avgBpm, 140);
@@ -81,7 +81,7 @@ void main() {
 
     test('motion confirmation gate: low motion drops it, high keeps it', () {
       final d = _hrDay();
-      // Low motion over the bout → below motionConfirmMean (0.05).
+      // Low motion over the bout → below motionConfirmMean (0.15).
       final lowMotion = [
         for (var t = 600; t <= 1499; t++) MotionPoint(t, 0.01),
       ];
@@ -111,7 +111,7 @@ void main() {
       final bpm = <int>[];
       for (var t = 0; t < 780; t++) {
         ts.add(t);
-        // dip to 70 (below floor 90) for [400,460).
+        // dip to 70 (below floor 100) for [400,460).
         bpm.add((t >= 400 && t < 460) ? 70 : 140);
       }
       final out = AutoWorkoutDetector.detect(hrTs: ts, hrBpm: bpm, restingBpm: 60);


### PR DESCRIPTION
This pull request makes significant improvements to the auto-detection of workouts and expands the coaching/test coverage. The workout detection algorithm is now more robust against false positives, with new logic for heart rate thresholds, motion confirmation, and time-bounding of detected workouts. The coaching API test suite is expanded to cover edge cases and regression scenarios, ensuring more reliable behavior. Several tests and comments are updated to reflect the new detection logic.

**Workout Detection Improvements:**

* The heart rate elevation threshold now uses a heart-rate reserve (HRR) fraction (default 0.45) with a safety floor, and the minimum margin above resting HR is increased from 30 to 40 bpm. This makes detection more robust, especially for users with lower max HR. [[1]](diffhunk://#diff-f534de947488dc9bbdb33735f99f2a3add2c2569d661df51b2c450fbf11515d6L77-R97) [[2]](diffhunk://#diff-f534de947488dc9bbdb33735f99f2a3add2c2569d661df51b2c450fbf11515d6L150-R178)
* Added a time-bound limit: detected workouts longer than 2 hours (120 min) are ignored to avoid misclassifying long lifestyle activities as workouts. [[1]](diffhunk://#diff-f534de947488dc9bbdb33735f99f2a3add2c2569d661df51b2c450fbf11515d6L77-R97) [[2]](diffhunk://#diff-f534de947488dc9bbdb33735f99f2a3add2c2569d661df51b2c450fbf11515d6R232-R235)
* The motion confirmation threshold is raised from 0.05 to 0.15, reducing false positives from low-intensity activities like fidgeting.
* The mean heart rate for the entire detected window must now exceed the floor, not just brief excursions, further reducing false positives.
* The API now accepts an optional `maxBpm` parameter for more accurate HRR calculations, with corresponding updates to the detector and API. [[1]](diffhunk://#diff-f534de947488dc9bbdb33735f99f2a3add2c2569d661df51b2c450fbf11515d6R162) [[2]](diffhunk://#diff-f534de947488dc9bbdb33735f99f2a3add2c2569d661df51b2c450fbf11515d6R315) [[3]](diffhunk://#diff-f534de947488dc9bbdb33735f99f2a3add2c2569d661df51b2c450fbf11515d6R324)

**Test Suite and Documentation Enhancements:**

* The coaching test suite is greatly expanded, covering the sleep need calculation, performance, bedtime/wake recommendations, strain targeting, VO2max estimation, physiological age, and journal correlations, including edge cases and regression tests. [[1]](diffhunk://#diff-ae6347bc653788883b46ede527fab87ed84304d20cb118718e369a3652cc5b8bL2-R2) [[2]](diffhunk://#diff-ae6347bc653788883b46ede527fab87ed84304d20cb118718e369a3652cc5b8bR17-R50) [[3]](diffhunk://#diff-ae6347bc653788883b46ede527fab87ed84304d20cb118718e369a3652cc5b8bR59-R244) [[4]](diffhunk://#diff-ae6347bc653788883b46ede527fab87ed84304d20cb118718e369a3652cc5b8bL72-R414)
* Test comments and expected values are updated to match the new detection logic, ensuring ongoing alignment between implementation and tests. [[1]](diffhunk://#diff-75689bec8496d4a37fc84920c5f093eafb2381a1679ec7c1ae378e2861373425L43-R43) [[2]](diffhunk://#diff-75689bec8496d4a37fc84920c5f093eafb2381a1679ec7c1ae378e2861373425L84-R84) [[3]](diffhunk://#diff-75689bec8496d4a37fc84920c5f093eafb2381a1679ec7c1ae378e2861373425L114-R114)

These changes collectively make the workout and coaching modules more accurate, robust, and maintainable.Restore uncommitted work reverted by an editor rewind, recovered from Claude Code file-history snapshots (pre-15:23 versions). Verified: edge analyze 0 errors + 103 tests pass; analytics 258 tests pass; protocol analyze clean.

Deltas over HEAD: unified BLE connector + offload-frame pipeline (ble_engine), compute_jobs durable derive queue (db), DeriveScheduler ingest/derive decoupling, derivation_engine, local_repository_impl, background_sync, backend_client.