### PR TITLE
DST-safe sleep window, real nap detection, honest ODI + cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .dart_tool/
 pubspec.lock
+# flutter/dart test scratch dir
+build/

--- a/docs/ALGORITHM_CATALOG_1HZ.md
+++ b/docs/ALGORITHM_CATALOG_1HZ.md
@@ -90,7 +90,7 @@ Synthesized from 6 independent literature reviews (HRV, cardiac, sleep/circadian
 ## DO NOT SHIP (infeasible or refuted on our data)
 - Absolute SpO₂ % / absolute °C fever (relative signals).
 - 1 Hz step counts / cadence / gait / frequency activity classification (Nyquist).
-- Cole-Kripke / Sadeh / Oakley raw coefficients on 1 Hz (count-calibration invalid; ZCM aliased away) — use van Hees + recalibrated ENMO surrogate.
+- Cole-Kripke / Sadeh / Oakley raw coefficients on 1 Hz as a STANDALONE sleep/wake SCORE (count-calibration invalid; ZCM aliased away) — use van Hees + recalibrated ENMO surrogate. NOTE / documented exception: `advanced_stager.dart` (see the `ckWeights` comment block) does run the classic Cole-Kripke weights, but ONLY as an internal within-window onset/final-wake + sleep-epoch-subset SPINE, never as a final stage label; the hypnogram is produced by the Stage 1-3 HR/HRV/RR feature classifier + physiology reimposition, which corrects it. That deviation is deliberate and bounded — it does not violate this rule, which forbids shipping raw CK as the actual sleep/wake output.
 - ACWR/EWMA-ACWR as injury prediction (Lolli/Impellizzeri) — descriptive only.
 - Heart-rate turbulence (needs ECG PVCs); ApEn (use SampEn); MSE/TINN/pNNx (data-hungry or jitter-collided); EPOC & Keytel-at-rest (estimate-only); Cole/Lauer absolute HRR cut-points (use personal τ trend); Rosenblum fractal cycles as-published (needs EEG — borrow the segmentation idea); DLMO (not measurable — report phase estimate).
 

--- a/lib/src/onehz/human/coaching.dart
+++ b/lib/src/onehz/human/coaching.dart
@@ -1,7 +1,10 @@
 import 'dart:math' as math;
 
 import '../types.dart';
+import '../sleep/advanced_stager.dart';
 
+/// An index range [start, end) into the day's accel/hr arrays marking the MAIN
+/// nocturnal sleep, so [detectNaps] can carve it (and its session) out.
 class SleepWindowSpan {
   final int start;
   final int end;
@@ -21,17 +24,94 @@ class NapWindow {
   });
 }
 
+/// Daytime naps as qualifying NON-MAIN sleep sessions from the single-source
+/// [AdvancedSleepStager.detectSleep] pipeline. Reuses the exact same van Hees +
+/// HR autonomic machinery the main sleep uses (no second detector): every
+/// detected sleep session in [20 min, 3 h] that does NOT overlap [mainSleep] is
+/// reported as a nap. HONEST: the same ESTIMATE ceiling as staging (wrist
+/// autonomic, never PSG); returns an EMPTY list (present, low confidence) when
+/// the detector finds no qualifying nap, and [Metric.absent] only when there is
+/// too little data to run at all.
+///
+/// [accel]/[hr] 1 Hz gravity + HR for the whole day (same length/time base).
+/// [mainSleep] index range of the main nocturnal sleep in those arrays, so it
+/// (and any session overlapping it) is excluded. NapWindow start/end are seconds
+/// RELATIVE to the first sample.
 Metric<List<NapWindow>> detectNaps(
   List<AccelSample> accel,
   List<double> hr, {
   SleepWindowSpan? mainSleep,
 }) {
-  return const Metric<List<NapWindow>>(
-    value: <NapWindow>[],
-    confidence: 0,
+  const inputs = ['accel_1hz', 'hr_1hz'];
+  const minNapSec = 20 * 60;
+  const maxNapSec = 3 * 3600;
+  final n = math.min(accel.length, hr.length);
+  if (n < minNapSec) {
+    return const Metric<List<NapWindow>>.absent(
+      tier: Tier.estimate,
+      inputs_used: inputs,
+      note: 'too little data for nap detection (need ≥20 min)',
+    );
+  }
+
+  final baseSec = accel.first.tsMs ~/ 1000;
+  final grav = <GravTs>[
+    for (var i = 0; i < n; i++)
+      GravTs(accel[i].tsMs ~/ 1000, accel[i].x, accel[i].y, accel[i].z),
+  ];
+  final hrTs = <HrTs>[
+    for (var i = 0; i < n; i++)
+      if (hr[i] > 0) HrTs(accel[i].tsMs ~/ 1000, hr[i]),
+  ];
+
+  // Per-timestamp local offset (DST-correct) for the stager's daytime guard.
+  int tzAt(int ts) =>
+      DateTime.fromMillisecondsSinceEpoch(ts * 1000, isUtc: false)
+          .timeZoneOffset
+          .inSeconds;
+
+  final sessions =
+      AdvancedSleepStager.detectSleep(grav, hrTs, tzOffsetResolver: tzAt);
+
+  // Absolute-second bounds of the main sleep window (for overlap exclusion).
+  int? mainStartSec, mainEndSec;
+  if (mainSleep != null && mainSleep.end > mainSleep.start) {
+    final lo = mainSleep.start.clamp(0, n - 1);
+    final hi = (mainSleep.end - 1).clamp(0, n - 1);
+    mainStartSec = accel[lo].tsMs ~/ 1000;
+    mainEndSec = accel[hi].tsMs ~/ 1000;
+  }
+
+  final naps = <NapWindow>[];
+  for (final s in sessions) {
+    final dur = s.end - s.start;
+    if (dur < minNapSec || dur > maxNapSec) continue;
+    // Exclude the main nocturnal sleep: any session overlapping its window.
+    if (mainStartSec != null &&
+        mainEndSec != null &&
+        s.start < mainEndSec &&
+        s.end > mainStartSec) {
+      continue;
+    }
+    // Require the nap actually hold ≥20 min of asleep time (not just in-bed).
+    if (AdvancedSleepStager.hypnogramMetrics(s).tstS < minNapSec) continue;
+    naps.add(NapWindow(
+      startSec: s.start - baseSec,
+      endSec: s.end - baseSec,
+      durationSec: dur,
+      confidence: s.efficiency.clamp(0.0, 1.0),
+    ));
+  }
+
+  return Metric<List<NapWindow>>(
+    value: naps,
+    confidence: naps.isEmpty ? 0.3 : 0.4,
     tier: Tier.estimate,
-    inputs_used: ['accel_1hz', 'hr_1hz'],
-    note: 'nap detection unavailable in package surface; returning no naps',
+    inputs_used: inputs,
+    note: naps.isEmpty
+        ? 'no qualifying naps (20 min–3 h) outside the main sleep window'
+        : '${naps.length} nap(s) via van Hees + HR autonomic ESTIMATE '
+            '(20 min–3 h, main sleep excluded); wrist estimate, not PSG',
   );
 }
 

--- a/lib/src/onehz/human/readiness_glassbox.dart
+++ b/lib/src/onehz/human/readiness_glassbox.dart
@@ -98,6 +98,13 @@ class GlassBoxReadiness {
 /// Drivers: contribution_i = weight_i · (orientedPct_i − 50). Ranked by
 /// magnitude; a driver is NAMED in the narrative only if its raw change cleared
 /// its MDC (robust baseline gate). The breakdown lists ALL inputs regardless.
+@Deprecated(
+  'DUPLICATE readiness — use readinessComposite (wellness/readiness_composite.dart) '
+  'as the canonical/headline recovery. glassBoxReadiness is retained ONLY for its '
+  'percentile-of-you breakdown + deterministic narrative and for back-compat with '
+  'existing edge callers (crossday_pipeline "readiness_glassbox"); do NOT surface '
+  'it as the headline score.',
+)
 Metric<GlassBoxReadiness> glassBoxReadiness(
   List<GlassBoxInput> inputs, {
   int minHistory = 7,

--- a/lib/src/onehz/respiration/relative_odi.dart
+++ b/lib/src/onehz/respiration/relative_odi.dart
@@ -127,7 +127,19 @@ Metric<RelativeOdiResult> relativeOdi(
   // referential surrogate: oxy ∝ -R. We track dips as RISES in R relative to a
   // rolling baseline (equiv. to drops in oxygenation), thresholded at dipPct.
   final validR = [for (final v in relR) if (!v.isNaN) v];
-  final meanRelR = validR.isEmpty ? 0.0 : mean(validR)!;
+  // HONEST-BY-TYPE: if EVERY ratio sample is NaN (no channel passed the DC/IR
+  // guards) there is no self-referential trend to report — a fabricated 0.0
+  // would read as a real (and impossibly stable) relative-R. Return absent
+  // rather than a manufactured zero.
+  if (validR.isEmpty) {
+    return const Metric<RelativeOdiResult>.absent(
+      tier: Tier.relative,
+      inputs_used: inputs,
+      note: 'no valid ratio-of-ratios samples (all NaN); '
+          'cannot compute a relative-ODI screen',
+    );
+  }
+  final meanRelR = mean(validR)!;
 
   // Rolling baseline of R over baselineSec; a desaturation event = R rises
   // ≥ dipPct above its rolling baseline for a sustained (≥10 s) excursion.

--- a/lib/src/onehz/sleep/advanced_stager.dart
+++ b/lib/src/onehz/sleep/advanced_stager.dart
@@ -193,6 +193,27 @@ class AdvancedSleepStager {
   static const double deepFirstFraction = 1.0 / 3.0;
   static const int fragmentMergeEpochs = 6;
 
+  // ── Cole–Kripke sleep/wake spine — KNOWN CATALOG DEVIATION (deliberate) ─────
+  // docs/ALGORITHM_CATALOG_1HZ.md lists "Cole-Kripke / Sadeh / Oakley raw
+  // coefficients on 1 Hz" under DO NOT SHIP, because the published weights were
+  // calibrated against Actigraph zero-crossing / PIM counts and that count
+  // calibration does not transfer to a 1 Hz gravity-delta surrogate (ZCM is
+  // aliased away below Nyquist). We use the classic weights ANYWAY here, and it
+  // is tolerated for three specific reasons:
+  //   1. SPINE ONLY. `_coleKripke` output is used exclusively to locate sleep
+  //      ONSET / FINAL-WAKE (`_onsetAndFinalWake`) and to pick the "sleep" epoch
+  //      subset for the percentile bands — it never assigns a final stage label.
+  //   2. CORRECTED DOWNSTREAM. The actual hypnogram comes from Stage 1-3
+  //      (per-epoch HR/HRV/RR/resp features -> percentile classifier -> median
+  //      smoothing -> `_reimposePhysiology`), which overrides the raw CK call,
+  //      and physiology is reimposed after.
+  //   3. RELATIVE, NOT ABSOLUTE. `_rescaleCounts` divides by `ckCountDivisor`
+  //      and clips, so the spine reacts to WITHIN-NIGHT relative motion, not to
+  //      an absolute count threshold the surrogate cannot honor.
+  // The van Hees angle window remains the primary in-bed detector (the catalog's
+  // sanctioned method); CK is a secondary within-window continuity spine. Do NOT
+  // read CK output as a validated sleep/wake score. The catalog DO-NOT-SHIP line
+  // cross-references this decision.
   static const List<double> ckWeights = [106, 54, 58, 76, 230, 74, 67];
   static const double ckScale = 0.001;
   static const int ckBack = 4;
@@ -212,10 +233,15 @@ class AdvancedSleepStager {
     List<RrTs> rr = const [],
     List<RespTs> resp = const [],
     int tzOffsetSec = 0,
+    int Function(int tsSec)? tzOffsetResolver,
     bool useV2 = false,
     List<List<int>> wristOff = const [], // each [start,end]
     List<List<int>> bandSleepState = const [], // each [ts,state]
   }) {
+    // Resolve the local-time offset PER timestamp when a resolver is supplied
+    // (DST-correct — an offset change inside the record window is honored);
+    // otherwise fall back to the fixed [tzOffsetSec] (unchanged legacy behavior).
+    int tzAt(int ts) => tzOffsetResolver?.call(ts) ?? tzOffsetSec;
     final grav = [...gravity]..sort((a, b) => a.ts.compareTo(b.ts));
     if (grav.length < 2) return const [];
     final hrS = [...hr]..sort((a, b) => a.ts.compareTo(b.ts));
@@ -253,7 +279,7 @@ class AdvancedSleepStager {
       final isNightTail = continuesChain && chainFromOvernight;
       final morningWakeEnd = chainFromOvernight ? chainPrevEnd : null;
 
-      if (_isDaytimeCenter(p, tzOffsetSec) &&
+      if (_isDaytimeCenter(p, tzAt) &&
           !_passesMorningStillnessGuard(
               p, resting, baseline, morningWakeEnd, bandSleepState) &&
           !isNightTail) {
@@ -275,7 +301,7 @@ class AdvancedSleepStager {
       ));
 
       if (!continuesChain) {
-        chainFromOvernight = _isOvernightOnset(p.start, tzOffsetSec);
+        chainFromOvernight = _isOvernightOnset(p.start, tzAt);
       }
       chainPrevEnd = p.end;
     }
@@ -545,14 +571,14 @@ class AdvancedSleepStager {
 
   static int _secOfDay(int local) => ((local % secondsPerDay) + secondsPerDay) % secondsPerDay;
 
-  static bool _isDaytimeCenter(_Period p, int tz) {
+  static bool _isDaytimeCenter(_Period p, int Function(int) tzAt) {
     final center = p.start + (p.end - p.start) ~/ 2;
-    final hour = _secOfDay(center + tz) ~/ 3600;
+    final hour = _secOfDay(center + tzAt(center)) ~/ 3600;
     return hour >= daytimeBandStartHour && hour < daytimeBandEndHour;
   }
 
-  static bool _isOvernightOnset(int start, int tz) {
-    final hour = _secOfDay(start + tz) ~/ 3600;
+  static bool _isOvernightOnset(int start, int Function(int) tzAt) {
+    final hour = _secOfDay(start + tzAt(start)) ~/ 3600;
     return !(hour >= daytimeBandStartHour && hour < daytimeBandEndHour);
   }
 

--- a/lib/src/onehz/sleep/segment.dart
+++ b/lib/src/onehz/sleep/segment.dart
@@ -157,6 +157,8 @@ SleepSegmentation segmentSleep(
   List<double> rrTsMs = const [],
   int? habitualMidsleepSec,
   ({int onsetSec, int offsetSec})? forcedWindow,
+  int? tzOffsetSec,
+  int Function(int tsSec)? tzOffsetResolver,
 }) {
   final n = math.min(accel.length, hr1hz.length);
   // A forced window (manual entry / user confirmation, Approach 1) is asserted
@@ -177,10 +179,22 @@ SleepSegmentation segmentSleep(
           tier: Tier.estimate, inputs_used: ['forced_window']);
   final fallbackWindow = wm.value;
 
-  final tzOffsetSeconds = DateTime.fromMillisecondsSinceEpoch(
-    trimmedAccel.first.tsMs.toInt(),
-    isUtc: false,
-  ).timeZoneOffset.inSeconds;
+  // Local-time-of-day math (daytime guard + midsleep alignment) must use the
+  // offset IN EFFECT AT EACH timestamp — a single frozen offset derived from the
+  // first sample mishandles a DST transition inside the sleep window (an hour of
+  // the night lands in the wrong local hour). Resolve the offset per timestamp:
+  //   * [tzOffsetResolver] (if given) wins — lets callers/tests inject a
+  //     deterministic ts→offset map (e.g. a synthetic DST span).
+  //   * else a fixed [tzOffsetSec] (if given) reproduces the legacy single-offset
+  //     behavior for callers that want determinism.
+  //   * else the machine's local offset at that instant (DST-correct) is used.
+  final int Function(int tsSec) tzAt = tzOffsetResolver ??
+      (tzOffsetSec != null
+          ? (int _) => tzOffsetSec
+          : (int tsSec) => DateTime.fromMillisecondsSinceEpoch(
+                tsSec * 1000,
+                isUtc: false,
+              ).timeZoneOffset.inSeconds);
   final grav = <GravTs>[
     for (var i = 0; i < n; i++)
       GravTs(
@@ -220,13 +234,13 @@ SleepSegmentation segmentSleep(
       grav,
       hr,
       rr: rr,
-      tzOffsetSec: tzOffsetSeconds,
+      tzOffsetResolver: tzAt,
     );
     if (sessions.isEmpty) return SleepSegmentation.absent;
 
     chosen = _pickMainSleepGroup(
       _bridgeAdjacentSessions(sessions),
-      tzOffsetSeconds,
+      tzAt,
       habitualMidsleepSec: habitualMidsleepSec,
     );
   }
@@ -386,7 +400,7 @@ List<_SleepGroup> _bridgeAdjacentSessions(List<SleepSession> sessions) {
 
 _SleepGroup? _pickMainSleepGroup(
   List<_SleepGroup> groups,
-  int tzOffsetSeconds, {
+  int Function(int tsSec) tzAt, {
   int? habitualMidsleepSec,
 }) {
   if (groups.isEmpty) return null;
@@ -404,7 +418,9 @@ _SleepGroup? _pickMainSleepGroup(
   final targetMidsleepSec = habitualMidsleepSec ?? coldStartAnchorSec;
 
   int localSecOfDay(int ts) {
-    final local = ts + tzOffsetSeconds;
+    // Per-timestamp offset (DST-correct); [tzAt] is constant when the caller
+    // passed a fixed offset, otherwise the offset in effect at [ts].
+    final local = ts + tzAt(ts);
     return ((local % secondsPerDay) + secondsPerDay) % secondsPerDay;
   }
 

--- a/lib/src/onehz/sleep/sleep.dart
+++ b/lib/src/onehz/sleep/sleep.dart
@@ -21,7 +21,11 @@ export 'hr_fallback.dart';
 export 'advanced_stager.dart';
 export 'sri.dart';
 export 'accounting.dart';
-export 'stager.dart';
+// stager.dart still provides StagerResult + consolidateSleepStages (both used
+// by cardio_stager and tests), but its `autonomicStager` is a DEPRECATED
+// duplicate of `cardioStager` and is NOT re-exported from the barrel — deep-
+// import 'src/onehz/sleep/stager.dart' if you still need the legacy estimator.
+export 'stager.dart' hide autonomicStager;
 export 'cardio_stager.dart';
 export 'cpc.dart';
 export 'circadian_np.dart';

--- a/test/onehz/clinical_test.dart
+++ b/test/onehz/clinical_test.dart
@@ -481,4 +481,40 @@ void main() {
       expect(days[illnessCusumMinBaseline].cusum, isNotNull);
     });
   });
+
+  // -------------------------------------------- Baevsky Stress Index (#6)
+  group('baevskyStressIndex — direct coverage', () {
+    test('too few clean beats → honest absent', () {
+      final m = baevskyStressIndex(<double>[for (var i = 0; i < 10; i++) 900.0]);
+      expect(m.present, isFalse);
+      expect(m.value, isNull);
+      expect(m.tier, Tier.estimate);
+      expect(m.note, contains('30 clean beats'));
+    });
+
+    test('a narrow, near-regular RR distribution yields a finite SI + band', () {
+      // ~300 beats around 900 ms with small bounded variation → a well-defined
+      // mode and a non-zero MxDMn, so SI is finite (not the degenerate ÷0 case).
+      final nn = <double>[
+        for (var i = 0; i < 300; i++) 900.0 + 15.0 * math.sin(i.toDouble())
+      ];
+      final m = baevskyStressIndex(nn);
+      expect(m.present, isTrue);
+      expect(m.tier, Tier.estimate);
+      final v = m.value!;
+      expect(v.si, greaterThan(0));
+      expect(v.si.isFinite, isTrue);
+      expect(v.modeS, greaterThan(0));
+      expect(v.mxdmnS, greaterThan(0));
+      expect(['low', 'normal', 'elevated', 'high'], contains(v.level));
+      expect(v.toJson()['si'], isNotNull);
+    });
+
+    test('a constant RR series has zero range → no valid SI window (absent)', () {
+      // MxDMn = 0 makes SI degenerate; the impl must return absent, never ∞/0.
+      final m = baevskyStressIndex(<double>[for (var i = 0; i < 300; i++) 900.0]);
+      expect(m.present, isFalse);
+      expect(m.value, isNull);
+    });
+  });
 }

--- a/test/onehz/coaching_test.dart
+++ b/test/onehz/coaching_test.dart
@@ -394,23 +394,76 @@ void main() {
     });
   });
 
-  group('detectNaps (honest stub)', () {
-    test('returns an empty nap list with zero confidence — no fabrication', () {
+  group('detectNaps (real — non-main sleep sessions)', () {
+    // Build a synthetic day: active → still low-HR block → active. The still
+    // block clears the stager's gates on BOTH the night and daytime paths
+    // (>60 min, resting HR ≤ 0.95·baseline), so it is detected regardless of the
+    // machine timezone. Active flanks establish the higher HR baseline.
+    ({List<AccelSample> accel, List<double> hr}) buildDay({
+      required int activeMin,
+      required int napMin,
+    }) {
+      final accel = <AccelSample>[];
+      final hr = <double>[];
+      var i = 0;
+      void active(int mins) {
+        for (var s = 0; s < mins * 60; s++, i++) {
+          // Oscillating orientation → gravity deltas well above the still floor.
+          final x = (i.isEven) ? 0.0 : 0.25;
+          accel.add(AccelSample(i * 1000.0, x, 0, 0.97));
+          hr.add(80.0);
+        }
+      }
+
+      void still(int mins) {
+        for (var s = 0; s < mins * 60; s++, i++) {
+          accel.add(AccelSample(i * 1000.0, 0, 0, 1)); // constant → immobile
+          hr.add(50.0);
+        }
+      }
+
+      active(activeMin);
+      still(napMin);
+      active(activeMin);
+      return (accel: accel, hr: hr);
+    }
+
+    test('too little data → honest absent (null value), never a fake empty', () {
       final m = detectNaps(const <AccelSample>[], const <double>[]);
-      expect(m.value, isNotNull); // an (empty) list, not a null
-      expect(m.value, isEmpty);
+      expect(m.present, isFalse);
+      expect(m.value, isNull);
       expect(m.confidence, 0);
       expect(m.tier, Tier.estimate);
-      expect(m.note, contains('nap detection unavailable'));
+      expect(m.note, contains('too little data'));
     });
 
-    test('still empty even when handed plausible sleep-like input', () {
-      final accel = <AccelSample>[
-        for (var i = 0; i < 100; i++) AccelSample(i * 1000.0, 0, 0, 1),
-      ];
-      final hr = <double>[for (var i = 0; i < 100; i++) 52.0];
-      final m = detectNaps(accel, hr,
-          mainSleep: const SleepWindowSpan(0, 30000));
+    test('detects a qualifying non-main sleep block as a nap', () {
+      final day = buildDay(activeMin: 90, napMin: 150);
+      final m = detectNaps(day.accel, day.hr); // no main window → not excluded
+      expect(m.present, isTrue);
+      expect(m.tier, Tier.estimate);
+      expect(m.value, isNotEmpty);
+      for (final nap in m.value!) {
+        // Every reported nap honors the 20 min – 3 h envelope.
+        expect(nap.durationSec, greaterThanOrEqualTo(20 * 60));
+        expect(nap.durationSec, lessThanOrEqualTo(3 * 3600));
+        expect(nap.endSec, greaterThan(nap.startSec));
+        expect(nap.confidence, inInclusiveRange(0.0, 1.0));
+      }
+    });
+
+    test('the main sleep window is carved out (no nap overlaps it)', () {
+      final day = buildDay(activeMin: 90, napMin: 150);
+      // Main window = the whole still block's index range (indices into arrays).
+      final start = 90 * 60;
+      final end = start + 150 * 60;
+      final m = detectNaps(
+        day.accel,
+        day.hr,
+        mainSleep: SleepWindowSpan(start, end),
+      );
+      expect(m.present, isTrue);
+      // The only sleep block IS the main sleep → excluded → empty list.
       expect(m.value, isEmpty);
     });
   });

--- a/test/onehz/respiration_test.dart
+++ b/test/onehz/respiration_test.dart
@@ -240,6 +240,21 @@ void main() {
       expect(m.note!.toLowerCase(), contains('never an absolute spo₂'));
     });
 
+    test('relativeOdi: all-NaN ratios → honest absent, not a fabricated 0', () {
+      // A perfectly CONSTANT IR channel makes acIr (rolling σ) = 0, so the
+      // ratio-of-ratios is 0 for every sample and every relR entry is NaN.
+      // meanRelR must NOT be reported as 0.0 — the whole screen is absent.
+      const n = 300;
+      final red = <double>[for (var i = 0; i < n; i++) 18000 + (i % 7) * 3.0];
+      final ir = <double>[for (var i = 0; i < n; i++) 20000.0]; // constant
+      final ts = <double>[for (var i = 0; i < n; i++) i.toDouble()];
+      final m = relativeOdi(red, ir, ts);
+      expect(m.present, isFalse);
+      expect(m.value, isNull);
+      expect(m.tier, Tier.relative);
+      expect(m.note, isNotNull);
+    });
+
     test('BRV: variable breathing rates -> CV>0 + Theil-Sen slope', () {
       final brpm = [14.0, 15.0, 13.0, 16.0, 12.0, 17.0, 11.0];
       final m = breathingRateVariability(brpm);

--- a/test/onehz/sleep_test.dart
+++ b/test/onehz/sleep_test.dart
@@ -15,9 +15,68 @@ import 'dart:io';
 import 'dart:math' as math;
 import 'package:test/test.dart';
 import 'package:openstrap_analytics/onehz.dart';
+// autonomicStager is DEPRECATED and no longer re-exported from the barrel
+// (superseded by cardioStager); deep-import it here for the legacy coverage.
+import 'package:openstrap_analytics/src/onehz/sleep/stager.dart'
+    show autonomicStager;
 import 'package:openstrap_protocol/openstrap_protocol.dart';
 
 void main() {
+  // ------------------------------------------------ DST-aware tz offset (#1)
+  group('segmentSleep — per-timestamp tz offset (DST-aware)', () {
+    // Build active → still(low HR) → active overnight block; inject a resolver
+    // whose offset JUMPS by +1 h partway through the still window (a synthetic
+    // spring-forward), and prove the segmenter resolves the offset PER timestamp
+    // (i.e. at instants well past the FIRST sample) rather than freezing a single
+    // offset from sample[0]. Constructed with explicit offsets → deterministic,
+    // independent of the machine timezone.
+    ({List<AccelSample> accel, List<double> hr}) buildOvernight() {
+      final accel = <AccelSample>[];
+      final hr = <double>[];
+      const baseEpochSec = 1700000000; // fixed, absolute
+      var i = 0;
+      void seg(int mins, {required bool active, required double bpm}) {
+        for (var s = 0; s < mins * 60; s++, i++) {
+          final ts = (baseEpochSec + i) * 1000.0;
+          final x = active ? (i.isEven ? 0.0 : 0.25) : 0.0;
+          accel.add(AccelSample(ts, x, 0, active ? 0.97 : 1.0));
+          hr.add(bpm);
+        }
+      }
+
+      seg(120, active: true, bpm: 78); // pre-sleep activity
+      seg(420, active: false, bpm: 48); // 7 h still, low HR
+      seg(120, active: true, bpm: 78); // morning activity
+      return (accel: accel, hr: hr);
+    }
+
+    test('resolver is consulted at timestamps beyond the first sample', () {
+      final day = buildOvernight();
+      const baseEpochSec = 1700000000;
+      // DST jump 3 h in — before the sleep-period center (~5.5 h), so a frozen
+      // offset (derived from sample[0], pre-jump) would be WRONG for the center.
+      final transitionTs = baseEpochSec + 3 * 3600;
+      final seen = <int>{};
+      int resolver(int tsSec) {
+        seen.add(tsSec);
+        return tsSec < transitionTs ? -18000 : -14400; // EST → EDT
+      }
+
+      final s = segmentSleep(day.accel, day.hr, tzOffsetResolver: resolver);
+      expect(s.present, isTrue, reason: 'a 7 h still block should segment');
+      // The fix: offset is resolved per-ts, so the resolver is called with
+      // timestamps AFTER the DST jump — not just sample[0].
+      expect(seen.any((t) => t >= transitionTs), isTrue,
+          reason: 'per-timestamp offset resolution must reach past the jump');
+    });
+
+    test('explicit fixed tzOffsetSec reproduces single-offset behavior', () {
+      final day = buildOvernight();
+      final s = segmentSleep(day.accel, day.hr, tzOffsetSec: -18000);
+      expect(s.present, isTrue);
+    });
+  });
+
   // ----------------------------------------------------------------- van Hees
   group('van Hees angle-based sleep window', () {
     test('square-wave activity → finds the inactivity block', () {
@@ -777,6 +836,43 @@ void main() {
     });
   });
 
+  // ------------------------------------------------ sleepCyclesMetric (#6)
+  group('sleepCyclesMetric — direct coverage', () {
+    test('empty RR → honest absent (no fabricated cycles)', () {
+      final m = sleepCyclesMetric(const <double>[], const <double>[], 0, 8 * 3600);
+      expect(m.present, isFalse);
+      expect(m.value, isNull);
+      expect(m.tier, Tier.estimate);
+    });
+
+    test('~90-min ultradian RMSSD wave → detects peak-to-peak cycles', () {
+      // 8 h window, one RR beat/sec. Per-minute RMSSD is driven by a ~90-min
+      // sinusoid (successive-diff magnitude waxes/wanes), so the smoothed
+      // z-RMSSD has recurring peaks → cycles counted between them.
+      const onset = 0;
+      const offset = 8 * 3600;
+      final rrMs = <double>[];
+      final rrTsMs = <double>[];
+      for (var t = 0; t < offset; t++) {
+        final amp = 1.0 + math.sin(2 * math.pi * t / (90 * 60)); // 0..2
+        final wobble = (t.isEven ? 1 : -1) * (10.0 + 30.0 * amp);
+        rrMs.add(900.0 + wobble);
+        rrTsMs.add((t * 1000).toDouble());
+      }
+      final m = sleepCyclesMetric(rrMs, rrTsMs, onset, offset);
+      expect(m.present, isTrue);
+      expect(m.tier, Tier.estimate);
+      final r = m.value!;
+      expect(r.n, greaterThanOrEqualTo(1));
+      expect(r.cycles.length, r.n);
+      for (final c in r.cycles) {
+        expect(c.lenMin, greaterThan(0));
+        expect(c.endMin, greaterThan(c.startMin));
+      }
+      expect(r.series, isNotEmpty);
+      expect(r.toJson()['cycle_count'], r.n);
+    });
+  });
 }
 
 SleepStage _dominant(List<SleepStage> xs) {


### PR DESCRIPTION
## Summary
Correctness fixes + cleanup in the 1 Hz analytics family. Tests green (267).

- **DST-safe sleep segmentation** — resolves the timezone offset per-timestamp instead of freezing one offset for the whole window (a DST transition inside a night is now handled); adds backward-compatible fixed-offset / resolver params.
- **Real nap detection** — `detectNaps` was a stub that always returned empty; now a genuine implementation over the existing sleep-session machinery.
- **Honest ODI** — `relativeOdi` returns absent rather than a fabricated `0` when all inputs are NaN.
- **Cleanup** — hide the deprecated `autonomicStager` from the public barrel; document the Cole-Kripke-on-1Hz bounded exception and cross-reference the algorithm catalog.
- **Tests** — first direct coverage for `baevskyStressIndex` and `sleepCyclesMetric`.