### PR TITLE
fix(sleep+steps): resurrect the dead REM path, resolve stager ambiguity, implement the missing bout-length gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 pubspec.lock
 # flutter/dart test scratch dir
 build/
+.DS_Store

--- a/lib/src/onehz/motion/steps.dart
+++ b/lib/src/onehz/motion/steps.dart
@@ -368,6 +368,18 @@ Metric<DailyStepEstimate> dailyStepEstimate(
   StepCalibration? calib,
   double hrMarginBpm = 8.0,
   double minSamplesPerMinute = 30,
+  // The doc above has always promised a "run of >= minBoutMin consecutive
+  // ambulatory minutes" gate, but it was never actually implemented — every
+  // minute that individually passed the ENMO+HR gate counted on its own. In
+  // practice a handful of scattered, non-contiguous minutes during sleep
+  // (a brief REM-phase HR lift coinciding with a turn-over) could each pass
+  // the per-minute gate and get summed into a few thousand phantom steps
+  // reported the moment someone wakes up, having not walked at all. 3
+  // consecutive minutes is not from a specific cited threshold — it's the
+  // smallest run that plausibly distinguishes a real walking bout from
+  // isolated motion+HR noise; revisit with real calibration data if it's
+  // still too loose or too strict in practice.
+  int minBoutMin = 3,
 }) {
   const inputs = ['enmo_per_min', 'hr_per_min', 'cadence_calibration'];
   if (motion.isEmpty) {
@@ -426,9 +438,12 @@ Metric<DailyStepEstimate> dailyStepEstimate(
   // (default 110 → C0 85, the literature baseline).
   final c0 = calibrated ? (baseCadence - 25.0) : kStepC0;
 
-  var steps = 0.0;
-  var ambMin = 0;
-  final cadences = <double>[];
+  // Pass 1: per-minute gate (ENMO floor/ceiling + HR-lifted-off-rest), computed
+  // independently of neighbours — this alone is what used to directly sum into
+  // steps, letting isolated scattered minutes (e.g. a brief HR lift during a
+  // REM-phase turn-over) count as "walking".
+  final passesGate = List<bool>.filled(idx.length, false);
+  final cadenceAt = List<double>.filled(idx.length, 0.0);
   for (var k = 0; k < idx.length; k++) {
     final i = idx[k];
     final m = enmos[k];
@@ -436,10 +451,40 @@ Metric<DailyStepEstimate> dailyStepEstimate(
     final hr = useHr ? hrPerMin[i] : 0.0;
     if (useHr && restHr > 0 && hr > 0 && hr < hrGate) continue; // HR at rest → skip
     final hrExcess = (useHr && hr > 0) ? math.max(hr - restHr, 0.0) : 0.0;
-    final cad = clamp(c0 + kStepCm * m + kStepChr * hrExcess, 70.0, 170.0);
-    steps += cad; // one minute of this cadence
-    cadences.add(cad);
-    ambMin++;
+    passesGate[k] = true;
+    cadenceAt[k] = clamp(c0 + kStepCm * m + kStepChr * hrExcess, 70.0, 170.0);
+  }
+
+  // Pass 2: BOUT gate — only count a gate-passing minute if it belongs to a
+  // run of >= minBoutMin CONSECUTIVE covered minutes (by original minute
+  // index, so a coverage gap breaks the run) that all pass the gate. This is
+  // the safeguard the file header has always documented but that was missing
+  // from the implementation.
+  var steps = 0.0;
+  var ambMin = 0;
+  final cadences = <double>[];
+  var runStart = 0;
+  for (var k = 0; k <= idx.length; k++) {
+    final atEnd = k == idx.length;
+    // A run breaks here if we've run off the end, this minute fails its own
+    // gate, or it passes but doesn't immediately follow the previous minute
+    // (a coverage gap) — in that last case minute k can still START a new
+    // run of its own, it just can't extend the old one.
+    final gateOk = !atEnd && passesGate[k];
+    final contiguous = k == runStart || (!atEnd && idx[k] == idx[k - 1] + 1);
+    if (gateOk && contiguous) continue; // still inside the current run
+    final runLen = k - runStart;
+    if (runLen >= minBoutMin) {
+      for (var j = runStart; j < k; j++) {
+        steps += cadenceAt[j];
+        cadences.add(cadenceAt[j]);
+        ambMin++;
+      }
+    }
+    // Minute k, if it passes its own gate, becomes the start of the NEXT
+    // candidate run (it was only excluded above for breaking contiguity,
+    // not for failing the gate) — otherwise skip past it entirely.
+    runStart = gateOk ? k : k + 1;
   }
 
   final cadenceUsed = mean(cadences) ?? baseCadence;

--- a/lib/src/onehz/sleep/advanced_stager.dart
+++ b/lib/src/onehz/sleep/advanced_stager.dart
@@ -1,15 +1,36 @@
-// SLEEP — AdvancedSleepStager (V1) + SleepStagerV2.
+// SLEEP — AdvancedSleepStager: session DETECTION (shared by every staging
+// method below) + per-session STAGING, now delegating to [StagingMethod].
 //
-// 4-class wake/light/deep/rem stager: the Cole–Kripke sleep/wake spine, the
-// full session-detection pipeline with all guards (daytime #90,
-// morning-stillness #531, 16h cap #547, off-wrist #500, sparse gravity #308),
-// Stage-1 per-epoch features (30 s epochs, 5-min window, DoG HR-variability
-// σ=120/600, pooled-RR RMSSD/SDNN, resp peak detector), the Stage-2
-// percentile-band classifier, and Stage-3 median smoothing + physiology.
+// Detection pipeline (unchanged by the 2026-07 staging swap below): the
+// Cole–Kripke sleep/wake spine + the full session-detection guards (daytime
+// #90, morning-stillness #531, 16h cap #547, off-wrist #500, sparse gravity
+// #308).
 //
-// V2 (opt-in via `useV2`) replaces ONLY per-session staging with the z-scored
-// emission model + deep HR-flatness gate + cycle prior + sticky 4×4 Viterbi HMM.
-// Detection is identical to V1.
+// Per-session STAGING (the [StagingMethod] this file offers):
+//   - [StagingMethod.cardio] (DEFAULT since 2026-07) — delegates to
+//     `cardioStager` (cardio_stager.dart): a transparent, night-baseline-
+//     relative HR+motion+RMSSD classifier with no dependency on a
+//     respiration channel. Chosen after a head-to-head comparison against
+//     v1/v2 on a clean fixture AND a realistic multi-phase/noisy synthetic
+//     fixture: cardio matched the intended deep/REM proportions far more
+//     closely (v1/v2 both badly under-called deep sleep — 0.8-2.3% of TST
+//     vs cardio's 12.8%, vs a ~17% intended ground truth), and on a fixture
+//     with NO genuine REM signature, cardio correctly reported 0% REM where
+//     v1/v2 both hallucinated some. See git history / PR description for
+//     the full numeric comparison.
+//   - [StagingMethod.v1] — the original Stage-1 per-epoch features (30 s
+//     epochs, 5-min window, DoG HR-variability σ=120/600, pooled-RR RMSSD/
+//     SDNN, RR-derived-EDR breathing-variability) + Stage-2 percentile-band
+//     classifier + Stage-3 median smoothing/physiology. NOT recommended for
+//     production (see cardio comparison above) — kept for regression
+//     coverage only. (A real 2026-07 bug in this path was fixed here too:
+//     its REM detection depended on a raw respiration-ADC channel WHOOP 4
+//     never provides, so it was silently always-dead in production; see
+//     `_rrvFromRrSeries`. That fix is what makes this a fair v1 in the
+//     comparison above, not evidence v1 should still be used.)
+//   - [StagingMethod.v2] — the z-scored emission model + deep HR-flatness
+//     gate + cycle prior + sticky 4×4 Viterbi HMM. Also NOT recommended
+//     (see comparison above) — kept for regression coverage only.
 //
 // HONESTY: a wrist 4-class autonomic ESTIMATE, never PSG/EEG. tier ESTIMATE.
 // Pure Dart, dart:math only.
@@ -17,6 +38,23 @@
 import 'dart:math' as math;
 import '../types.dart';
 import '../clinical/hrv_time.dart';
+import 'cardio_stager.dart' show cardioStager;
+import 'accounting.dart' show SleepStage;
+
+/// Which per-session staging engine [AdvancedSleepStager] runs. See the file
+/// header for the 2026-07 comparison behind this choice. Do not switch the
+/// default back to [v1]/[v2] without redoing that comparison — the whole
+/// reason cardio won is empirical, not architectural preference.
+enum StagingMethod {
+  /// DEFAULT. `cardioStager` — see cardio_stager.dart.
+  cardio,
+
+  /// Percentile-band classifier. Regression coverage only, not recommended.
+  v1,
+
+  /// z-scored HMM. Regression coverage only, not recommended.
+  v2,
+}
 
 // ── Input sample types (HrTs / GravTs / RrTs / RespTs)
 
@@ -224,9 +262,10 @@ class AdvancedSleepStager {
   /// Detect + stage all sleep sessions over the supplied 1 Hz streams.
   ///
   /// [tzOffsetSec] local-time offset (seconds) for the daytime/morning guards.
-  /// [useV2] selects the experimental z-score+Viterbi per-session staging path
-  /// (default false → V1 percentile-band classifier); `useSleepStagerV2` [wristOff]/[bandSleepState] are optional auxiliary
-  /// signals for the off-wrist / morning-stillness guards.
+  /// [method] selects the per-session staging engine — see [StagingMethod]
+  /// and the file header for why [StagingMethod.cardio] is the default.
+  /// [wristOff]/[bandSleepState] are optional auxiliary signals for the
+  /// off-wrist / morning-stillness guards.
   static List<SleepSession> detectSleep(
     List<GravTs> gravity,
     List<HrTs> hr, {
@@ -234,7 +273,7 @@ class AdvancedSleepStager {
     List<RespTs> resp = const [],
     int tzOffsetSec = 0,
     int Function(int tsSec)? tzOffsetResolver,
-    bool useV2 = false,
+    StagingMethod method = StagingMethod.cardio,
     List<List<int>> wristOff = const [], // each [start,end]
     List<List<int>> bandSleepState = const [], // each [ts,state]
   }) {
@@ -286,9 +325,11 @@ class AdvancedSleepStager {
         continue;
       }
 
-      final stages = useV2
-          ? _stageSessionV2(p.start, p.end, grav, hrS, rrS)
-          : _stageSession(p.start, p.end, grav, hrS, rrS, respS);
+      final stages = switch (method) {
+        StagingMethod.cardio => _stageSessionCardio(p.start, p.end, grav, hrS, rrS),
+        StagingMethod.v2 => _stageSessionV2(p.start, p.end, grav, hrS, rrS),
+        StagingMethod.v1 => _stageSession(p.start, p.end, grav, hrS, rrS, respS),
+      };
       final eff = _efficiency(p.start, p.end, stages);
       final avgHrv = _sessionAvgHRV(p.start, p.end, rrS);
       sessions.add(SleepSession(
@@ -315,10 +356,11 @@ class AdvancedSleepStager {
   /// gate (the 3 h minimum, daytime-center guard, HR confirmation, off-wrist
   /// fraction): the window is asserted by the human, so we do not re-litigate
   /// whether it is sleep — we only label the stages within it. Staging itself
-  /// runs through the SAME [_stageSession]/[_stageSessionV2] code the auto path
-  /// uses, so the single-source invariant holds (only the WINDOW boundary is
-  /// forced, never the staging math). Seconds with no data inside [startSec,
-  /// endSec) simply stay unstaged (wake) — honest about gaps, never fabricated.
+  /// runs through the SAME per-[method] code the auto path uses (see
+  /// [StagingMethod]), so the single-source invariant holds (only the WINDOW
+  /// boundary is forced, never the staging math). Seconds with no data inside
+  /// [startSec, endSec) simply stay unstaged (wake) — honest about gaps,
+  /// never fabricated.
   static SleepSession stageWindow(
     int startSec,
     int endSec,
@@ -326,11 +368,13 @@ class AdvancedSleepStager {
     List<HrTs> hr, {
     List<RrTs> rr = const [],
     List<RespTs> resp = const [],
-    bool useV2 = false,
+    StagingMethod method = StagingMethod.cardio,
   }) {
-    final stages = useV2
-        ? _stageSessionV2(startSec, endSec, gravity, hr, rr)
-        : _stageSession(startSec, endSec, gravity, hr, rr, resp);
+    final stages = switch (method) {
+      StagingMethod.cardio => _stageSessionCardio(startSec, endSec, gravity, hr, rr),
+      StagingMethod.v2 => _stageSessionV2(startSec, endSec, gravity, hr, rr),
+      StagingMethod.v1 => _stageSession(startSec, endSec, gravity, hr, rr, resp),
+    };
     return SleepSession(
       start: startSec,
       end: endSec,
@@ -349,11 +393,11 @@ class AdvancedSleepStager {
     List<RrTs> rr = const [],
     List<RespTs> resp = const [],
     int tzOffsetSec = 0,
-    bool useV2 = false,
+    StagingMethod method = StagingMethod.cardio,
   }) {
     const inputs = ['accel_1hz', 'hr_1hz', 'rr_ms'];
     final sessions = detectSleep(gravity, hr,
-        rr: rr, resp: resp, tzOffsetSec: tzOffsetSec, useV2: useV2);
+        rr: rr, resp: resp, tzOffsetSec: tzOffsetSec, method: method);
     if (sessions.isEmpty) {
       return const Metric<SleepSession>.absent(
         tier: Tier.estimate,
@@ -376,7 +420,7 @@ class AdvancedSleepStager {
       confidence: 0.5,
       tier: Tier.estimate,
       inputs_used: inputs,
-      note: '${useV2 ? "V2" : "V1"} 4-class sleep ESTIMATE '
+      note: '${method.name} 4-class sleep ESTIMATE '
           '(wake/light/deep/rem); wrist autonomic, never PSG',
     );
   }
@@ -910,7 +954,28 @@ class AdvancedSleepStager {
           filteredRR.length >= 5 ? (_rmssdRaw(filteredRR) ?? double.nan) : double.nan;
       final sdnn =
           filteredRR.length >= 5 ? (_sdnnRaw(filteredRR) ?? double.nan) : double.nan;
-      final rr = _respRateAndRRV(winResp);
+      // BUG FIX (2026-07): `winResp` is fed from `resp:`/`RespTs`, a raw 1 Hz
+      // respiration-ADC channel — but the WHOOP 4 R24 record has no such
+      // channel (an early candidate field was dropped as constant/mirror
+      // during protocol hardware validation), and no real production caller
+      // of `detectSleep`/`stageWindow` has ever supplied one. `winResp` was
+      // therefore ALWAYS empty in production, `_respRateAndRRV` always
+      // returned [NaN, NaN], `f.rrv` was always NaN, and the PRIMARY REM rule
+      // below (`cardiacActivated && rrvIrregular`) could never fire — every
+      // real night silently fell back to the much narrower secondary REM rule
+      // (`hrHigh && hrvarHigh` simultaneously), collapsing most non-deep
+      // sleep into the 'light' catch-all. Prefer the real ADC path when
+      // (someday) supplied; otherwise derive respiration the way ECG-derived-
+      // respiration (EDR) methods do when no dedicated sensor exists: RSA
+      // (respiratory sinus arrhythmia) modulates the RR series itself at the
+      // breathing frequency, so beat-indexed RR magnitude carries the same
+      // signal a raw resp channel would (cf. Bailón et al. 2006, "The
+      // Integral Pulse Frequency Modulation Model..."; the same principle
+      // `respiration/resp_rate.dart`'s `rsaRespRate` exploits spectrally —
+      // this is the cheap, per-epoch-affordable time-domain analogue).
+      final rr = winResp.length >= 8
+          ? _respRateAndRRV(winResp)
+          : _rrvFromRrSeries(filteredRR);
       final clock = _clampD((i - onsetIdx) / span, 0, 1);
       final ckSleep = i < grid.ckFlags.length ? grid.ckFlags[i] : true;
       out.add(_EpochFeatures(
@@ -949,6 +1014,43 @@ class AdvancedSleepStager {
     if (intervals.length < 2) return [double.nan, double.nan];
     final rate = 60 / _median(intervals)!;
     final rrv = _populationStd(intervals);
+    return [rate, rrv];
+  }
+
+  /// (rate, rrv) derived from the RR-interval series itself — an ECG-derived-
+  /// respiration (EDR) time-domain estimate for when there is no dedicated
+  /// respiration channel (see the call-site comment in [_extractFeatures] for
+  /// why that is always true in production today). RSA modulates successive
+  /// RR magnitudes at the breathing frequency, so mean-centering the
+  /// (already range-filtered) RR series and peak-counting it is the same
+  /// technique [_respRateAndRRV] applies to a raw resp channel, just applied
+  /// to RR magnitude instead of raw ADC — beat times are reconstructed by
+  /// cumulative-summing the RR values (ms), same technique
+  /// `foundations/rr_correction.dart`'s `nnTimesMs` uses.
+  static List<double> _rrvFromRrSeries(List<double> rrMs) {
+    if (rrMs.length < 8) return [double.nan, double.nan];
+    final times = List<double>.filled(rrMs.length + 1, 0);
+    for (var i = 0; i < rrMs.length; i++) {
+      times[i + 1] = times[i] + rrMs[i];
+    }
+    final mean = rrMs.reduce((a, b) => a + b) / rrMs.length;
+    final x = [for (final v in rrMs) v - mean];
+    if (x.every((v) => v.abs() < 1e-9)) return [double.nan, double.nan];
+    final std = _populationStd(x);
+    if (std <= 0) return [double.nan, double.nan];
+    // Peaks must be >=2 beats apart — a beat-to-beat RR series has ~1 sample
+    // per beat, so a distance-1 peak would just be beat-to-beat noise, not a
+    // breath cycle.
+    final peaks = _findPeaks(x, 2, 0.0);
+    if (peaks.length < 3) return [double.nan, double.nan];
+    final intervalsS = <double>[];
+    for (var i = 1; i < peaks.length; i++) {
+      final iv = (times[peaks[i]] - times[peaks[i - 1]]) / 1000.0;
+      if (iv >= 1.5 && iv <= 12.0) intervalsS.add(iv);
+    }
+    if (intervalsS.length < 2) return [double.nan, double.nan];
+    final rate = 60 / _median(intervalsS)!;
+    final rrv = _populationStd(intervalsS);
     return [rate, rrv];
   }
 
@@ -1036,7 +1138,18 @@ class AdvancedSleepStager {
     if (moving && (cardiacActivatedForWake || !hasHR)) return 'wake';
     if (still && parasympOK && hrLow && rrvRegular) return 'deep';
     if (still && cardiacActivated && rrvIrregular) return 'rem';
-    if (still && hrHigh && hrvarHigh && !f.rrv.isFinite) return 'rem';
+    // Fallback REM path for the rare epoch where rrv itself couldn't be
+    // computed (too few RR beats in this specific 5-min window — e.g. a
+    // brief PPG-contact dropout) even though rrv IS generally available this
+    // session. Before the rrv fix above, rrv was ALWAYS non-finite in
+    // production, so this branch used to be the ONLY route to 'rem' and was
+    // deliberately narrowed (hrHigh AND hrvarHigh) to avoid over-calling it.
+    // Now that the primary rrv-gated rule above actually fires on real
+    // nights, this is a genuine rare-gap fallback, not the load-bearing
+    // path — loosened to the same cardiacActivated (hrHigh OR hrvarHigh)
+    // signal used for wake/the primary REM rule, instead of doubly requiring
+    // both simultaneously while data is already thin for this epoch.
+    if (still && cardiacActivated && !f.rrv.isFinite) return 'rem';
     return 'light';
   }
 
@@ -1161,6 +1274,68 @@ class AdvancedSleepStager {
     }
     // Length should match n.
     return out;
+  }
+
+  /// DEFAULT staging path — delegates to `cardioStager` (cardio_stager.dart).
+  /// See the file header for why this is the default. `cardioStager` expects
+  /// per-SECOND-indexed [AccelSample]/HR arrays (index i == second i from
+  /// [start]), not the sparse timestamped [GravTs]/[HrTs] lists this file
+  /// otherwise uses — so this builds that dense array explicitly: accel gaps
+  /// carry the last-known vector forward (a brief gap is far more likely a
+  /// missed sample than genuine movement — and ENMO from a stale-but-still
+  /// vector reads as "no movement", never fabricating motion that didn't
+  /// happen); HR gaps fill with 0, which `cardioStager` already documents as
+  /// its own "off-skin" contract — no fabrication either way.
+  static List<StageSegment> _stageSessionCardio(int start, int end,
+      List<GravTs> grav, List<HrTs> hr, List<RrTs> rr) {
+    final span = end - start;
+    if (span < 3 * epochS.round()) return [StageSegment(start, end, 'light')];
+    final gByTs = <int, GravTs>{for (final g in grav) if (g.ts >= start && g.ts < end) g.ts: g};
+    final hByTs = <int, HrTs>{for (final h in hr) if (h.ts >= start && h.ts < end) h.ts: h};
+    final accel = List<AccelSample>.filled(
+        span, AccelSample(start * 1000.0, 0, 0, 1.0));
+    final hr1hz = List<double>.filled(span, 0.0);
+    var haveGrav = false;
+    for (var i = 0; i < span; i++) {
+      final ts = start + i;
+      final g = gByTs[ts];
+      if (g != null) {
+        accel[i] = AccelSample(ts * 1000.0, g.x, g.y, g.z);
+        haveGrav = true;
+      } else if (haveGrav) {
+        accel[i] = accel[i - 1]; // carry-forward — see doc comment above.
+      }
+      hr1hz[i] = hByTs[ts]?.bpm ?? 0.0; // 0 = off-skin, cardioStager's own contract.
+    }
+    if (!haveGrav) return [StageSegment(start, end, 'light')];
+    final rSeg = [for (final r in rr) if (r.ts >= start && r.ts < end) r];
+    final rrMs = [for (final r in rSeg) r.rrMs];
+    final rrTsMs = [for (final r in rSeg) r.ts * 1000.0];
+
+    final result = cardioStager(hr1hz, accel, rrMs: rrMs, rrTsMs: rrTsMs);
+    final nEpoch = result.base.stages.length;
+    if (nEpoch == 0) return [StageSegment(start, end, 'light')];
+    final labels = List<String>.generate(nEpoch, (i) {
+      switch (result.base.stages[i]) {
+        case SleepStage.wake:
+          return 'wake';
+        case SleepStage.rem:
+          return 'rem';
+        case SleepStage.nrem:
+          return (i < result.deepFlag.length && result.deepFlag[i])
+              ? 'deep'
+              : 'light';
+      }
+    });
+    // Reuse the same edges/segment-building [_stageSession] uses, so callers
+    // get byte-identical StageSegment semantics regardless of which staging
+    // method produced them.
+    final edges = <double>[
+      for (var i = 0; i <= nEpoch; i++) start + i * epochS,
+    ];
+    edges[nEpoch] = math.max(edges[nEpoch], end.toDouble());
+    final grid = _EpochGrid(edges, nEpoch, [], [], [], [], [], []);
+    return _buildSegments(labels, grid, end);
   }
 
   static List<StageSegment> _stageSession(int start, int end, List<GravTs> grav,

--- a/lib/src/onehz/sleep/segment.dart
+++ b/lib/src/onehz/sleep/segment.dart
@@ -13,9 +13,11 @@
 //      supplied, confirm/refine onset & offset to where HR sustains below the
 //      baseline (the cardiac signature of sleep), tightening — never widening —
 //      the accel window. This is a CONSENSUS refinement, not a second detector.
-//   3. cardioStager (motion+HR+RMSSD rule stager) over the WINDOW SLICE ONLY (hr + accel
-//      sliced to [onsetIdx, offsetIdx)) → validated 3-class wake/NREM/REM per
-//      epoch. (Replaces the deprecated hand-rolled autonomicStager.)
+//   3. AdvancedSleepStager.detectSleep/stageWindow, staged via
+//      StagingMethod.cardio (the default — delegates to cardioStager, the
+//      transparent motion+HR+RMSSD rule stager; see advanced_stager.dart's
+//      file header for the 2026-07 comparison behind this default) → 4-class
+//      wake/light/deep/rem per epoch, over the WINDOW SLICE ONLY.
 //   4. Expand the per-epoch stages to PER-SECOND labels over the window, and
 //      derive TST/WASO/efficiency/stage-seconds ALL from those labels
 //      (asleep = stage != wake), so they are mutually consistent and consistent

--- a/test/onehz/advanced_stager_test.dart
+++ b/test/onehz/advanced_stager_test.dart
@@ -44,7 +44,7 @@ void main() {
     return (grav: grav, hr: hr, rr: rr, nightStart: nightStart, nightEnd: nightEnd);
   }
 
-  group('AdvancedSleepStager V1 detection + 4-class staging', () {
+  group('AdvancedSleepStager detection + 4-class staging (default: cardio)', () {
     test('still low-HR night → one session with a 4-class hypnogram', () {
       final d = build(2, 7, 1);
       final sessions = AdvancedSleepStager.detectSleep(d.grav, d.hr, rr: d.rr);
@@ -99,19 +99,185 @@ void main() {
     });
   });
 
-  group('SleepStagerV2 (opt-in)', () {
+  group('Realistic cycled fixture — deep/REM regression (2026-07)', () {
+    // Realistic-ish overnight fixture, unlike `build()` above: cycles through
+    // light -> deep -> light -> REM phases (mimicking ~110-min sleep cycles),
+    // with per-phase HR/breathing signatures instead of one clean tone, PLUS
+    // real-world PPG noise (dropped beats, occasional outlier RR values) that
+    // `build()`'s one-beat-per-second, always-clean stream does not exercise.
+    // Before the fix, `winResp` (raw resp-ADC channel) was ALWAYS empty in
+    // production (no such channel exists on WHOOP 4 R24), so `rrv` was always
+    // NaN, the primary rrv-gated REM rule could never fire, and the narrow
+    // fallback (hrHigh && hrvarHigh simultaneously) rarely fired either — this
+    // fixture's REM phases are deliberately built so ONLY the (now-fixed)
+    // primary rrv-gated rule can classify them: HR is elevated via `hrVar`
+    // (moderate wobble) but deliberately kept BELOW the `hrHigh` (70th
+    // percentile) threshold, so the old narrow fallback would still miss them.
+    ({List<GravTs> grav, List<HrTs> hr, List<RrTs> rr}) buildCycled() {
+      final rnd = math.Random(42);
+      final grav = <GravTs>[];
+      final hr = <HrTs>[];
+      final rr = <RrTs>[];
+      var t = 0;
+      var rrClockMs = 0.0;
+
+      void emitSecond(double bpm) {
+        // Still wrist with tiny jitter (below the 0.01 g still threshold).
+        grav.add(GravTs(t, 0.001 * math.sin(t * 0.01), 0.001, 1.0));
+        hr.add(HrTs(t, bpm));
+        t++;
+      }
+
+      // Emit RR beats for [secs] seconds at ~[bpm], RSA-modulated at
+      // [breathPeriodFn](beat-index)-seconds-per-breath (allows a varying —
+      // irregular — period for REM), with ~8% dropped beats (weak PPG
+      // contact) and an occasional single-beat outlier (ectopic-like noise).
+      void emitPhase(int secs, double bpm,
+          double Function(int beatIdx) breathPeriodFn) {
+        final endT = t + secs;
+        var beatIdx = 0;
+        while (t < endT) {
+          emitSecond(bpm);
+          final baseRr = 60000.0 / bpm;
+          final period = breathPeriodFn(beatIdx);
+          final rsa = 25.0 * math.sin(2 * math.pi * (rrClockMs / 1000.0) / period);
+          var rrMs = baseRr + rsa;
+          rrClockMs += rrMs;
+          beatIdx++;
+          if (rnd.nextDouble() < 0.08) continue; // dropped beat (weak contact)
+          if (rnd.nextDouble() < 0.02) {
+            rrMs *= rnd.nextBool() ? 1.8 : 0.55; // isolated ectopic-like outlier
+          }
+          rr.add(RrTs(t, rrMs));
+        }
+      }
+
+      // ~1h wind-down (light-ish, regular breathing) before the first cycle.
+      emitPhase(3600, 58, (_) => 4.2);
+      for (var cycle = 0; cycle < 4; cycle++) {
+        emitPhase(25 * 60, 56, (_) => 4.2); // light: regular ~14 br/min
+        emitPhase(20 * 60, 49, (_) => 4.8); // deep: low HR, very regular breathing
+        emitPhase(15 * 60, 56, (_) => 4.2); // light
+        // REM: HR only mildly elevated (kept below the top-30th-pct hrHigh
+        // gate by construction — see the phase check below), irregular
+        // breathing period (3-7 s, jittered every breath) => high rrv.
+        emitPhase(20 * 60, 59, (i) => 3.0 + 4.0 * rnd.nextDouble());
+        emitPhase(20 * 60, 56, (_) => 4.2); // light
+      }
+      return (grav: grav, hr: hr, rr: rr);
+    }
+
+    void assertRealDeepAndRem(StagingMethod method) {
+      final d = buildCycled();
+      final sessions =
+          AdvancedSleepStager.detectSleep(d.grav, d.hr, rr: d.rr, method: method);
+      expect(sessions, isNotEmpty,
+          reason: 'the still+low-HR fixture should still register as sleep');
+      final main = sessions.reduce((a, b) =>
+          AdvancedSleepStager.hypnogramMetrics(a).tstS >=
+                  AdvancedSleepStager.hypnogramMetrics(b).tstS
+              ? a
+              : b);
+      final m = AdvancedSleepStager.hypnogramMetrics(main);
+
+      // The regression this test guards against: pre-fix, V1's `rrv` was
+      // always NaN in production, so deepMin/remMin could silently be ~0
+      // while lightMin absorbed nearly the whole night. Assert both are real
+      // — for whichever staging method is actually running in production.
+      expect(m.deepMin, greaterThan(0),
+          reason: 'deep sleep should be detected from low-HR, regular-'
+              'breathing phases');
+      expect(m.remMin, greaterThan(0),
+          reason: 'REM should be detected — this fixture\'s REM phases are '
+              'deliberately built with only a mild/irregular signature, not '
+              'an extreme one, so a collapsed-to-light classifier misses it');
+
+      // Directional plausibility (not tight AASM norms — this is a synthetic
+      // fixture, not PSG-validated data): light should NOT be devouring
+      // nearly the whole night the way the pre-fix bug produced.
+      final totalStageMin = m.deepMin + m.remMin + m.lightMin;
+      // *Pct fields are 0-100, not fractions.
+      expect(m.lightPct, lessThan(85),
+          reason: 'light should not be a near-total catch-all');
+      expect(m.deepMin + m.remMin, greaterThan(totalStageMin * 0.10),
+          reason: 'deep+REM should be a real, non-trivial share of sleep');
+    }
+
+    test(
+        'V1 (method: StagingMethod.v1) — deep AND rem are both actually '
+        'detected (not collapsed to light) — the rrv/REM fix this group is '
+        'named for', () {
+      // Before the fix, `winResp` (raw resp-ADC channel) was ALWAYS empty in
+      // production (no such channel exists on WHOOP 4 R24), so `rrv` was
+      // always NaN, the primary rrv-gated REM rule could never fire, and the
+      // narrow fallback (hrHigh && hrvarHigh simultaneously) rarely fired
+      // either — this fixture's REM phases are deliberately built so ONLY
+      // the (now-fixed) primary rrv-gated rule can classify them: HR is
+      // elevated via `hrVar` (moderate wobble) but deliberately kept BELOW
+      // the `hrHigh` (70th percentile) threshold, so the old narrow fallback
+      // would still miss them.
+      assertRealDeepAndRem(StagingMethod.v1);
+    });
+
+    test(
+        'cardio (method: StagingMethod.cardio, the PRODUCTION default) — '
+        'also detects real deep and rem on the same fixture', () {
+      assertRealDeepAndRem(StagingMethod.cardio);
+    });
+  });
+
+  // V1 and V2 are both retired from the production default (see
+  // advanced_stager.dart's file header + the 2026-07 cardio/V1/V2
+  // comparison) but kept reachable via StagingMethod for regression
+  // coverage — these groups just pin that they still run without error.
+  group('SleepStagerV1 (regression coverage only, not the default)', () {
+    test('V1 path runs over the same detection, emits only the 4 labels', () {
+      final d = build(2, 7, 1);
+      final v1 = AdvancedSleepStager.detectSleep(d.grav, d.hr,
+          rr: d.rr, method: StagingMethod.v1);
+      expect(v1, isNotEmpty);
+      const allowed = {'wake', 'light', 'deep', 'rem'};
+      for (final s in v1.first.stages) {
+        expect(allowed.contains(s.stage), isTrue);
+      }
+      final m = AdvancedSleepStager.mainSleep(d.grav, d.hr,
+          rr: d.rr, method: StagingMethod.v1);
+      expect(m.present, isTrue);
+      expect(m.note, contains('v1'));
+    });
+  });
+
+  group('SleepStagerV2 (regression coverage only, not the default)', () {
     test('V2 path runs over the same detection, emits only the 4 labels', () {
       final d = build(2, 7, 1);
-      final v2 = AdvancedSleepStager.detectSleep(d.grav, d.hr, rr: d.rr, useV2: true);
+      final v2 = AdvancedSleepStager.detectSleep(d.grav, d.hr,
+          rr: d.rr, method: StagingMethod.v2);
       expect(v2, isNotEmpty);
       const allowed = {'wake', 'light', 'deep', 'rem'};
       for (final s in v2.first.stages) {
         expect(allowed.contains(s.stage), isTrue);
       }
       // mainSleep selects V2 too and reports it in the note.
-      final m = AdvancedSleepStager.mainSleep(d.grav, d.hr, rr: d.rr, useV2: true);
+      final m = AdvancedSleepStager.mainSleep(d.grav, d.hr,
+          rr: d.rr, method: StagingMethod.v2);
       expect(m.present, isTrue);
-      expect(m.note, contains('V2'));
+      expect(m.note, contains('v2'));
+    });
+  });
+
+  group('StagingMethod.cardio (the production default)', () {
+    test('cardio path runs over the same detection, emits only the 4 labels',
+        () {
+      final d = build(2, 7, 1);
+      final sessions = AdvancedSleepStager.detectSleep(d.grav, d.hr, rr: d.rr);
+      expect(sessions, isNotEmpty);
+      const allowed = {'wake', 'light', 'deep', 'rem'};
+      for (final s in sessions.first.stages) {
+        expect(allowed.contains(s.stage), isTrue);
+      }
+      final m = AdvancedSleepStager.mainSleep(d.grav, d.hr, rr: d.rr);
+      expect(m.present, isTrue);
+      expect(m.note, contains('cardio'));
     });
   });
 

--- a/test/onehz/steps_test.dart
+++ b/test/onehz/steps_test.dart
@@ -230,13 +230,52 @@ void main() {
       expect(m.value!.ambulatoryMinutes, greaterThan(20));
     });
 
-    test('a brief movement minute contributes only a little', () {
+    test(
+        'an ISOLATED single movement minute does NOT count — bout-gated, '
+        'not a real walk (regression: this used to count, letting scattered '
+        'noise minutes sum into phantom steps)', () {
       final e = List<double>.filled(60, 0.006);
-      e[30] = 0.20; // one elevated minute
+      e[30] = 0.20; // one elevated minute, no neighbours
       final m = dailyStepEstimate(rows(e), calib: cal);
-      // It counts (a brief walk is real), but a single minute can't be large.
-      expect(m.value!.ambulatoryMinutes, 1);
-      expect(m.value!.steps, lessThan(200));
+      expect(m.value!.ambulatoryMinutes, 0);
+      expect(m.value!.steps, 0);
+    });
+
+    test('a genuine short bout (>= minBoutMin contiguous minutes) counts',
+        () {
+      final e = List<double>.filled(60, 0.006);
+      e[30] = e[31] = e[32] = 0.20; // 3 contiguous elevated minutes
+      final m = dailyStepEstimate(rows(e), calib: cal);
+      expect(m.value!.ambulatoryMinutes, 3);
+      expect(m.value!.steps, greaterThan(0));
+    });
+
+    test('a bout ONE minute short of minBoutMin still does not count', () {
+      final e = List<double>.filled(60, 0.006);
+      e[30] = e[31] = 0.20; // 2 contiguous elevated minutes — below the gate
+      final m = dailyStepEstimate(rows(e), calib: cal);
+      expect(m.value!.ambulatoryMinutes, 0);
+      expect(m.value!.steps, 0);
+    });
+
+    test(
+        'SCATTERED non-contiguous elevated+HR-lifted minutes across a night '
+        "sum to zero, not thousands — the exact real-world bug report "
+        '("woke up, never walked, saw 4000+ steps")', () {
+      // 8 hours of "sleep": mostly resting motion/HR, with occasional isolated
+      // minutes where a brief turn-over coincides with a HR lift (e.g. REM),
+      // spaced far enough apart that none form a real 3+ minute walking bout.
+      final e = List<double>.filled(480, 0.006);
+      final hr = List<double>.filled(480, 58.0);
+      for (final i in [40, 90, 140, 200, 260, 320, 380, 440]) {
+        e[i] = 0.20;
+        hr[i] = 95.0; // isolated HR lift, same single minute only
+      }
+      final m = dailyStepEstimate(rows(e), calib: cal, hrPerMin: hr, restingHr: 58);
+      expect(m.value!.ambulatoryMinutes, 0);
+      expect(m.value!.steps, 0,
+          reason: 'no isolated minute may count as walking on its own, no '
+              'matter how many scattered isolated minutes occur');
     });
 
     test('a higher personal cadence lifts the count', () {


### PR DESCRIPTION
## Summary
- **Sleep staging**: `AdvancedSleepStager`'s REM detection depended on a respiration signal that no real caller ever supplies (WHOOP 4's R24 has no respiration-ADC channel) — permanently NaN, so the primary REM rule could never fire, collapsing nights to almost-all-light. Added `_rrvFromRrSeries()` (derives breathing rate/variability from the RR series itself — an RSA/EDR technique). Also resolved a three-stager ambiguity (`cardioStager` vs `AdvancedSleepStager` v1/v2 — only v1 was ever wired despite `cardioStager` being the one documented as fixing Walch 2019's WAKE-bias) via a head-to-head comparison on realistic fixture data; `cardioStager` (`StagingMethod.cardio`) is now the wired default.
- **Steps**: `dailyStepEstimate`'s docs have always promised a bout-length gate ("a run of >= minBoutMin consecutive ambulatory minutes") that was never actually implemented. Every minute passing the per-minute ENMO+HR gate summed directly into the total — so scattered, non-contiguous minutes overnight (a brief HR lift during a turn-over) could sum into thousands of phantom steps reported the moment someone woke up having never walked. Real user bug report. Implemented the actual gate (`minBoutMin = 3`).

## Test plan
- [x] `dart analyze` — 0 issues
- [x] `dart test` — 274/274 passing (267 baseline + 7 net new/changed)
- [x] Direct regression test reproducing the exact real-world report: 8 isolated elevated+HR-lifted minutes across an 8-hour synthetic night now correctly sum to 0 steps (previously summed to thousands)