### PR TITLE
feat: real cardiac-coherence metric for guided breathing sessions

### DIFF
--- a/lib/onehz.dart
+++ b/lib/onehz.dart
@@ -32,6 +32,7 @@ export 'src/onehz/clinical/cosinor.dart';
 export 'src/onehz/clinical/load_trimp.dart';
 export 'src/onehz/clinical/stress_si.dart';
 export 'src/onehz/clinical/irregular_rhythm.dart';
+export 'src/onehz/clinical/cardiac_coherence.dart';
 
 // Metric families (each a self-contained barrel over the foundations + clinical).
 export 'src/onehz/sleep/sleep.dart';

--- a/lib/src/onehz/clinical/cardiac_coherence.dart
+++ b/lib/src/onehz/clinical/cardiac_coherence.dart
@@ -1,0 +1,146 @@
+// CLINICAL — real-time "cardiac coherence" from live RR during a guided
+// paced-breathing session.
+//
+// McCraty & Zayas 2014 ("Emotional Stress, Positive Emotions, and
+// Psychophysiological Coherence", Frontiers in Psychology), building on
+// McCraty, Atkinson, Tomasino & Bradley 2009 ("The Coherent Heart"). The
+// method: take the Lomb-Scargle PSD of the beat-to-beat tachogram, find the
+// single dominant peak within 0.04-0.26 Hz (the range paced/resonance
+// breathing entrains RSA into), integrate power in a narrow window around
+// that peak (+/- 0.015 Hz), and divide by the REMAINING spectral power. A
+// clean, single, regular oscillation (breathing-entrained RSA) produces a
+// high ratio; a noisy/irregular tachogram produces a low one.
+//
+// HONESTY:
+//   * This is PRV (wrist-PPG beat timing), not ECG-HRV — ESTIMATE tier.
+//   * A live guided session is short (~1-2 min) vs. HeartMath's classic 3-5
+//     min protocol, so the peak-frequency estimate is correspondingly
+//     noisier — confidence scales with span length.
+//   * The raw [ratio] is the cited measure. The 0-100 [score] is OUR OWN
+//     saturating display map (score = 100*ratio/(ratio+1)) — NOT a published
+//     scale (HeartMath's own commercial coherence score uses a different,
+//     proprietary mapping we don't have access to). Documented as an
+//     engineering choice, same convention as e.g. steps.dart's minBoutMin.
+//   * Absent/insufficient input => null Metric, never a fabricated number.
+
+import '../types.dart';
+import '../util.dart';
+
+class CardiacCoherence {
+  /// Raw McCraty coherence ratio: peak-band power / remaining spectral power.
+  /// Unbounded, >= 0. This is the cited measure.
+  final double ratio;
+
+  /// 0-100 saturating display map of [ratio] (our own choice, not published).
+  final double score;
+
+  /// Dominant frequency found within the 0.04-0.26 Hz search band (Hz).
+  final double peakHz;
+
+  const CardiacCoherence({
+    required this.ratio,
+    required this.score,
+    required this.peakHz,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'ratio': round6(ratio),
+        'score': round6(score),
+        'peak_hz': round6(peakHz),
+      };
+}
+
+/// [nnMs] cleaned NN intervals (ms), [nnTimesMs] their cumulative beat times
+/// (ms) — pass `correctRr(...)`'s `.nn` / `.nnTimesMs` directly.
+///
+/// [pacedHz] the guided pacing frequency if known (e.g. 5.5 breaths/min ==
+/// 0.0917 Hz). Purely informational for the confidence/note — the search
+/// band stays McCraty's full 0.04-0.26 Hz regardless, since a user won't
+/// always be perfectly on-pace.
+Metric<CardiacCoherence> cardiacCoherence(
+  List<double> nnMs,
+  List<double> nnTimesMs, {
+  double? pacedHz,
+  int gridPoints = 400,
+}) {
+  const inputs = ['rr_cleaned', 'beat_times'];
+  if (nnMs.length < 20 || nnTimesMs.length != nnMs.length) {
+    return const Metric<CardiacCoherence>.absent(
+      tier: Tier.estimate,
+      inputs_used: inputs,
+      note: 'too few beats for a coherence estimate',
+    );
+  }
+
+  final tSec = [for (final t in nnTimesMs) t / 1000.0];
+  final spanSec = tSec.last - tSec.first;
+  if (spanSec < 30) {
+    return const Metric<CardiacCoherence>.absent(
+      tier: Tier.estimate,
+      inputs_used: inputs,
+      note: 'session too short (< 30s) for a spectral estimate',
+    );
+  }
+
+  const searchLoHz = 0.04, searchHiHz = 0.26;
+  const totalHiHz = 0.4;
+  // Total-power floor can't resolve below ~1/span — mirrors hrvFreq's same
+  // honesty guard rather than pretending a short session sees down to 0.0033 Hz.
+  final totalLoHz = (1.0 / spanSec).clamp(0.0033, searchLoHz);
+
+  final ls = lombScargle(tSec, nnMs, freqGrid(totalLoHz, totalHiHz, gridPoints));
+  if (ls == null) {
+    return const Metric<CardiacCoherence>.absent(
+      tier: Tier.estimate,
+      inputs_used: inputs,
+      note: 'spectrum undefined',
+    );
+  }
+
+  final peakHz = ls.peakFreq(searchLoHz, searchHiHz);
+  if (peakHz == null) {
+    return const Metric<CardiacCoherence>.absent(
+      tier: Tier.estimate,
+      inputs_used: inputs,
+      note: 'no resolvable peak in the 0.04-0.26 Hz coherence band',
+    );
+  }
+
+  final peakPower = ls.bandPower(
+    (peakHz - 0.015).clamp(totalLoHz, totalHiHz),
+    (peakHz + 0.015).clamp(totalLoHz, totalHiHz),
+  );
+  final totalPower = ls.bandPower(totalLoHz, totalHiHz);
+  final remainder = totalPower - peakPower;
+  if (remainder <= 0) {
+    return const Metric<CardiacCoherence>.absent(
+      tier: Tier.estimate,
+      inputs_used: inputs,
+      note: 'degenerate spectrum (all power in the peak window)',
+    );
+  }
+
+  final ratio = peakPower / remainder;
+  final score = 100.0 * ratio / (ratio + 1.0);
+
+  final onPace = pacedHz != null && (peakHz - pacedHz).abs() < 0.02;
+  // Confidence scales with how much of HeartMath's classic 3-5 min protocol
+  // this span actually covers (floored/ceilinged), lightly penalized when the
+  // found peak isn't near the guided pace (could still be real RSA, just less
+  // clearly the paced-breathing entrainment this feature is meant to reward).
+  final conf = clamp(
+    (spanSec / 180.0).clamp(0.3, 1.0) * (onPace ? 1.0 : 0.85),
+    0.2,
+    0.9,
+  );
+
+  return Metric<CardiacCoherence>(
+    value: CardiacCoherence(ratio: ratio, score: score, peakHz: peakHz),
+    confidence: conf,
+    tier: Tier.estimate,
+    inputs_used: inputs,
+    note: onPace
+        ? 'peak matches guided pace — breathing-entrained RSA'
+        : 'peak off guided pace by > 0.02 Hz — may be natural RSA, not entrainment',
+  );
+}

--- a/test/onehz/clinical_test.dart
+++ b/test/onehz/clinical_test.dart
@@ -517,4 +517,86 @@ void main() {
       expect(m.value, isNull);
     });
   });
+
+  group('cardiac coherence (McCraty & Zayas 2014)', () {
+    // Synthesize ~2.5 min of RR cleanly modulated at 5.5 breaths/min
+    // (0.0917 Hz) — the guided resonance-breathing pace this feature targets.
+    List<double> pacedRr({double amplitudeMs = 60, int nBeats = 180}) {
+      final rr = <double>[];
+      var t = 0.0;
+      for (var i = 0; i < nBeats; i++) {
+        final v = 900 +
+            amplitudeMs * math.sin(2 * math.pi * 0.0917 * (t / 1000));
+        rr.add(v);
+        t += v;
+      }
+      return rr;
+    }
+
+    List<double> beatTimes(List<double> rr) {
+      final times = <double>[];
+      var t = 0.0;
+      for (final v in rr) {
+        t += v;
+        times.add(t);
+      }
+      return times;
+    }
+
+    test('finds the peak at the guided pace and reports a high ratio/score on a clean paced signal', () {
+      final rr = pacedRr();
+      final times = beatTimes(rr);
+      final m = cardiacCoherence(rr, times, pacedHz: 0.0917);
+      expect(m.present, isTrue);
+      expect(m.tier, Tier.estimate);
+      final v = m.value!;
+      // Peak should land within Lomb-Scargle grid resolution of 0.0917 Hz.
+      expect(v.peakHz, closeTo(0.0917, 0.01));
+      expect(v.ratio, greaterThan(1)); // a single clean oscillation dominates
+      expect(v.score, greaterThan(50));
+      expect(v.score, lessThanOrEqualTo(100));
+      expect(m.note, contains('matches guided pace'));
+    });
+
+    test('a noisy, unpaced tachogram yields a lower ratio/score than the clean paced one', () {
+      final rng = math.Random(7);
+      final noisyRr = <double>[
+        for (var i = 0; i < 180; i++) 900 + (rng.nextDouble() - 0.5) * 200,
+      ];
+      final noisyTimes = beatTimes(noisyRr);
+      final noisy = cardiacCoherence(noisyRr, noisyTimes, pacedHz: 0.0917);
+
+      final cleanRr = pacedRr();
+      final cleanTimes = beatTimes(cleanRr);
+      final clean = cardiacCoherence(cleanRr, cleanTimes, pacedHz: 0.0917);
+
+      expect(noisy.present, isTrue);
+      expect(clean.present, isTrue);
+      expect(noisy.value!.ratio, lessThan(clean.value!.ratio));
+      expect(noisy.value!.score, lessThan(clean.value!.score));
+    });
+
+    test('absent on too few beats', () {
+      final rr = pacedRr(nBeats: 10);
+      final m = cardiacCoherence(rr, beatTimes(rr));
+      expect(m.present, isFalse);
+      expect(m.value, isNull);
+      expect(m.confidence, 0);
+    });
+
+    test('absent on a span under 30s even with enough beats', () {
+      // 25 beats at ~1s each ≈ 25s span — plenty of beats, too short a window.
+      final rr = <double>[for (var i = 0; i < 25; i++) 1000.0];
+      final m = cardiacCoherence(rr, beatTimes(rr));
+      expect(m.present, isFalse);
+      expect(m.note, contains('too short'));
+    });
+
+    test('never fabricates: absent stays absent regardless of pacedHz', () {
+      final m = cardiacCoherence(<double>[800], <double>[800], pacedHz: 0.0917);
+      expect(m.present, isFalse);
+      expect(m.value, isNull);
+      expect(m.confidence, 0);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Adds `cardiacCoherence()` — a real, cited implementation of McCraty & Zayas 2014 cardiac coherence, computed from live RR during a guided-breathing session. This replaces edge's `calm_breathing_screen.dart`, which currently **fabricates its "coherence score" with `Random()`** — a direct violation of this project's "absent input → null, never fabricate" invariant. Companion edge PR wires it in.

## Method
- Reuses the existing Lomb-Scargle PSD infra (`lombScargle`/`peakFreq`/`bandPower` in `util.dart`, same infra `hrvFreq` already uses).
- Finds the dominant peak in the 0.04-0.26 Hz band (where paced/resonance breathing entrains RSA).
- Coherence ratio = power in a narrow window around that peak / remaining spectral power. A clean single oscillation → high ratio; noisy tachogram → low ratio.

## Honesty
- **ESTIMATE tier** — PRV not ECG-HRV, and a live session (~1-2 min) is shorter than HeartMath's classic 3-5 min protocol.
- The raw `ratio` is the cited measure. The 0-100 `score` (`100*ratio/(ratio+1)`) is explicitly documented as **our own saturating display map, not a published scale** (HeartMath's commercial coherence score uses a different, proprietary mapping).
- Absent/insufficient input returns an absent `Metric`, never a fabricated number — confirmed by test.

## Test plan
- [x] `dart test` — 277/277 green (272 + 5 new)
- [x] New tests: peak lands at the injected guided-pace frequency on a clean paced signal; noisy/unpaced signal yields a lower ratio+score than the clean one; absent on too few beats; absent on span < 30s; never fabricates regardless of `pacedHz`