### PR TITLE
feat: v42 personalized self-improving cardio stager

### DIFF
--- a/lib/src/onehz/sleep/advanced_stager.dart
+++ b/lib/src/onehz/sleep/advanced_stager.dart
@@ -304,7 +304,21 @@ class AdvancedSleepStager {
 
     for (final p in runs) {
       if (p.stage != 'sleep') continue;
-      if ((p.end - p.start) <= minSleepS) continue; // strict > 60 min
+      // Chain state must be known BEFORE the min-session floor: a night-tail
+      // re-onset (still, HR-in-band, within nightContinuationGapMin of the main
+      // overnight block) is genuine fragmented sleep even when shorter than the
+      // 60-min standalone floor. Computing it here (was below the floor) lets the
+      // floor exempt it — otherwise a pre-dawn arousal that splits off a <60-min
+      // tail silently truncates the window at the arousal.
+      final continuesChain = chainPrevEnd != null
+          ? (p.start - chainPrevEnd <= continuationGapS)
+          : false;
+      final isNightTail = continuesChain && chainFromOvernight;
+      // Min-session floor: standalone runs still need > 60 min (so daytime naps
+      // and stray still-blocks stay excluded); a night-tail continuation is
+      // exempt. The other gates below (max-span, HR-confirm, off-wrist) still
+      // apply to night-tails.
+      if ((p.end - p.start) <= minSleepS && !isNightTail) continue;
       if ((p.end - p.start) > maxMainSleepSpanS) continue; // #547 drop
       if (!_confirmSleepWithHR(p, hrS, baseline)) continue;
       if (_offWristFraction(p, hrS, wristOff) >= maxOffWristSleepFraction) {
@@ -312,10 +326,6 @@ class AdvancedSleepStager {
       }
 
       final resting = _sessionRestingHR(p.start, p.end, hrS);
-      final continuesChain = chainPrevEnd != null
-          ? (p.start - chainPrevEnd <= continuationGapS)
-          : false;
-      final isNightTail = continuesChain && chainFromOvernight;
       final morningWakeEnd = chainFromOvernight ? chainPrevEnd : null;
 
       if (_isDaytimeCenter(p, tzAt) &&

--- a/lib/src/onehz/sleep/advanced_stager.dart
+++ b/lib/src/onehz/sleep/advanced_stager.dart
@@ -300,6 +300,15 @@ class AdvancedSleepStager {
     const continuationGapS = nightContinuationGapMin * 60;
     int? chainPrevEnd;
     var chainFromOvernight = false;
+    // The floor exemption is one-shot per chain: only the FIRST *short* tail
+    // after the overnight block may bypass the 60-min floor. Without this a run
+    // of short morning/daytime fragments would each re-qualify (continuesChain
+    // stays true and chainFromOvernight never clears), chain-extending the window
+    // well past the true wake. Note a >60-min continuation is accepted on its own
+    // merit and does NOT consume the one-shot (it never needed the exemption), so
+    // a genuine multi-fragment pre-dawn tail still reaches the true wake. Set only
+    // when a short tail actually uses the exemption; cleared when a chain begins.
+    var nightTailAccepted = false;
     final sessions = <SleepSession>[];
 
     for (final p in runs) {
@@ -313,11 +322,12 @@ class AdvancedSleepStager {
       final continuesChain = chainPrevEnd != null
           ? (p.start - chainPrevEnd <= continuationGapS)
           : false;
-      final isNightTail = continuesChain && chainFromOvernight;
+      final isNightTail =
+          continuesChain && chainFromOvernight && !nightTailAccepted;
       // Min-session floor: standalone runs still need > 60 min (so daytime naps
-      // and stray still-blocks stay excluded); a night-tail continuation is
-      // exempt. The other gates below (max-span, HR-confirm, off-wrist) still
-      // apply to night-tails.
+      // and stray still-blocks stay excluded); ONLY the first SHORT night-tail
+      // per chain is exempt (nightTailAccepted bounds it). The other gates below
+      // (max-span, HR-confirm, off-wrist) still apply to night-tails.
       if ((p.end - p.start) <= minSleepS && !isNightTail) continue;
       if ((p.end - p.start) > maxMainSleepSpanS) continue; // #547 drop
       if (!_confirmSleepWithHR(p, hrS, baseline)) continue;
@@ -353,6 +363,12 @@ class AdvancedSleepStager {
 
       if (!continuesChain) {
         chainFromOvernight = _isOvernightOnset(p.start, tzAt);
+        nightTailAccepted = false; // new chain re-arms the one-shot exemption
+      } else if (isNightTail && (p.end - p.start) <= minSleepS) {
+        // Consume the one-shot ONLY when a SHORT tail actually relied on the floor
+        // exemption; a >60-min continuation passes the floor unaided and must not
+        // burn the exemption (else a later genuine short tail is lost).
+        nightTailAccepted = true;
       }
       chainPrevEnd = p.end;
     }

--- a/lib/src/onehz/sleep/cardio_stager.dart
+++ b/lib/src/onehz/sleep/cardio_stager.dart
@@ -59,9 +59,186 @@ class CardioStagerResult {
 
 const int _epochSec = 30;
 
+/// Robust-z cutoffs for the SECONDARY REM axes (LF/HF elevation, R(k) burst).
+/// Deliberately STRICT (4.0 robust-SD): the RMSSD drop is the PRIMARY REM
+/// detector; LF/HF and R(k) only ADD REM where a strong, unambiguous autonomic
+/// shift the RMSSD rule missed exists, so the OR-combination recovers
+/// under-called REM without stealing normal light sleep. Calibrated on the real
+/// 2026-07 overnight fixture (Apple-Watch GT: wake 3 / light 330 / deep 38 /
+/// REM 162 min). RMSSD-only under-called REM at 134 min; a threshold sweep
+/// showed z=2.5→204, 3.0→191, 3.5→182, 4.0→172 min REM. 4.0 lands closest to GT
+/// (REM 172, light 304) while still adding +38 min of strong-signature REM over
+/// RMSSD-only — a conservative, bounded sensitivity gain for the nights the
+/// RMSSD rule under-calls (the motivating case: 64 min REM vs a ~115 signature),
+/// erring toward specificity so the axes never re-open a Wake/REM over-call.
+const double _remLfhfZ = 4.0;
+const double _remRkZ = 4.0;
+
 /// Physiologic RR gate (project rule): keep 300–2000 ms; drop successive jumps
 /// > 200 ms (ectopy / artifact). Used per-window before RMSSD.
 const double _rrMin = 300, _rrMax = 2000, _rrMaxStep = 200;
+
+/// PER-USER rolling sleep profile — the "gets better over time" personalization.
+///
+/// The generic-ML experiment lost badly to this stager's PER-NIGHT LOCAL
+/// baselines (a DREAMT-trained model over-called Wake by 100+ min and read
+/// ~0 Deep on 3 real nights — between-person variance kills generic models).
+/// So the direction is MORE personalization, not less: persist the SLEEPER'S
+/// OWN typical sleep signatures across nights and blend them (bounded, never
+/// dominant) with tonight's per-night-local baselines.
+///
+/// Storage: edge `baselines` table, key `sleep_user_profile`, one JSON payload,
+/// folded via EWMA (~14-night horizon) after each finalized night. Blend weight
+/// grows from 0 (cold start) to a hard 0.5 cap as nights accumulate
+/// ([personalWeight]) — a single stored profile can NEVER outvote tonight's own
+/// signal, preserving the per-night-local behavior that won the head-to-head.
+///
+/// All fields nullable: absent ⇒ no personalization on that axis (honesty
+/// contract — never fabricate a baseline we don't have).
+class SleepUserProfile {
+  final int nights; // finalized nights folded so far (drives [personalWeight])
+  final double? hrFloorP5; // sleeping-HR 5th pct (bpm) — deep-sleep floor
+  final double? hrFloorP25; // sleeping-HR 25th pct (bpm) — REM HR gate
+  final double? hrSleepMedian; // sleeping-HR median (bpm)
+  final double? hrArousal; // typical arousal/wake HR threshold (bpm)
+  final double? rmssdMed; // sleeping RMSSD median (ms)
+  final double? rmssdMad; // sleeping RMSSD MAD (ms)
+  final double? enmoStillCut; // still/repositioning ENMO cut (g)
+  final double? enmoMoveCut; // big-move ENMO cut (g)
+  final double? lfhfMed; // sleeping LF/HF median
+  final double? rkMed; // sleeping |ΔIHR| median (bpm)
+  final int updatedAtMs;
+
+  const SleepUserProfile({
+    this.nights = 0,
+    this.hrFloorP5,
+    this.hrFloorP25,
+    this.hrSleepMedian,
+    this.hrArousal,
+    this.rmssdMed,
+    this.rmssdMad,
+    this.enmoStillCut,
+    this.enmoMoveCut,
+    this.lfhfMed,
+    this.rkMed,
+    this.updatedAtMs = 0,
+  });
+
+  /// Personal-vs-local blend weight: 0 at cold start → 0.5 hard cap at ≥14
+  /// nights (so per-night-local always holds ≥50% of every threshold).
+  double get personalWeight => clamp(nights / 28.0, 0.0, 0.5);
+
+  static double? _d(dynamic v) => (v is num) ? v.toDouble() : null;
+
+  factory SleepUserProfile.fromJson(Map<String, dynamic> j) => SleepUserProfile(
+        nights: (j['nights'] as num?)?.toInt() ?? 0,
+        hrFloorP5: _d(j['hr_floor_p5']),
+        hrFloorP25: _d(j['hr_floor_p25']),
+        hrSleepMedian: _d(j['hr_sleep_median']),
+        hrArousal: _d(j['hr_arousal']),
+        rmssdMed: _d(j['rmssd_med']),
+        rmssdMad: _d(j['rmssd_mad']),
+        enmoStillCut: _d(j['enmo_still_cut']),
+        enmoMoveCut: _d(j['enmo_move_cut']),
+        lfhfMed: _d(j['lfhf_med']),
+        rkMed: _d(j['rk_med']),
+        updatedAtMs: (j['updated_at_ms'] as num?)?.toInt() ?? 0,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'nights': nights,
+        if (hrFloorP5 != null) 'hr_floor_p5': hrFloorP5,
+        if (hrFloorP25 != null) 'hr_floor_p25': hrFloorP25,
+        if (hrSleepMedian != null) 'hr_sleep_median': hrSleepMedian,
+        if (hrArousal != null) 'hr_arousal': hrArousal,
+        if (rmssdMed != null) 'rmssd_med': rmssdMed,
+        if (rmssdMad != null) 'rmssd_mad': rmssdMad,
+        if (enmoStillCut != null) 'enmo_still_cut': enmoStillCut,
+        if (enmoMoveCut != null) 'enmo_move_cut': enmoMoveCut,
+        if (lfhfMed != null) 'lfhf_med': lfhfMed,
+        if (rkMed != null) 'rk_med': rkMed,
+        'updated_at_ms': updatedAtMs,
+      };
+
+  /// EWMA-fold one finalized night's observation into the profile, returning
+  /// the updated copy. Alpha eases from 1.0 (first night — take it whole) toward
+  /// a `2/(N+1)` floor (a ~[horizonNights]-night trailing memory), so cold start
+  /// adapts fast and settled profiles track the recent few weeks. A null
+  /// observed field leaves that axis untouched.
+  SleepUserProfile fold(SleepNightObservation o, {int horizonNights = 14}) {
+    final n2 = nights + 1;
+    final a = math.max(1.0 / n2, 2.0 / (horizonNights + 1));
+    double? ew(double? old, double? obs) =>
+        obs == null ? old : (old == null ? obs : old * (1 - a) + obs * a);
+    return SleepUserProfile(
+      nights: n2,
+      hrFloorP5: ew(hrFloorP5, o.hrFloorP5),
+      hrFloorP25: ew(hrFloorP25, o.hrFloorP25),
+      hrSleepMedian: ew(hrSleepMedian, o.hrSleepMedian),
+      hrArousal: ew(hrArousal, o.hrArousal),
+      rmssdMed: ew(rmssdMed, o.rmssdMed),
+      rmssdMad: ew(rmssdMad, o.rmssdMad),
+      enmoStillCut: ew(enmoStillCut, o.enmoStillCut),
+      enmoMoveCut: ew(enmoMoveCut, o.enmoMoveCut),
+      lfhfMed: ew(lfhfMed, o.lfhfMed),
+      rkMed: ew(rkMed, o.rkMed),
+      updatedAtMs: DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+}
+
+/// One night's observed sleep baselines, emitted by [cardioStager] for folding
+/// into a [SleepUserProfile]. [epochs] = staged epoch count (lets the caller
+/// pick the MAIN sleep among a night's sessions/naps, and reject short naps).
+class SleepNightObservation {
+  final int epochs;
+  final double? hrFloorP5;
+  final double? hrFloorP25;
+  final double? hrSleepMedian;
+  final double? hrArousal;
+  final double? rmssdMed;
+  final double? rmssdMad;
+  final double? enmoStillCut;
+  final double? enmoMoveCut;
+  final double? lfhfMed;
+  final double? rkMed;
+  const SleepNightObservation({
+    required this.epochs,
+    this.hrFloorP5,
+    this.hrFloorP25,
+    this.hrSleepMedian,
+    this.hrArousal,
+    this.rmssdMed,
+    this.rmssdMad,
+    this.enmoStillCut,
+    this.enmoMoveCut,
+    this.lfhfMed,
+    this.rkMed,
+  });
+}
+
+/// Ambient per-user profile used by [cardioStager] when no explicit
+/// `userProfile` arg is passed. Lets the edge derivation set it ONCE before
+/// running `segmentSleep` (which calls `cardioStager` deep inside
+/// `AdvancedSleepStager` with no param seam of its own). Single-isolate,
+/// synchronous-scope use only.
+SleepUserProfile? cardioUserProfile;
+
+/// When true, [cardioStager] appends one [SleepNightObservation] per run to an
+/// internal buffer. The edge sets this before a night's staging and reads the
+/// buffer with [takeCardioObservations] afterward to fold the MAIN sleep.
+bool cardioRecordObservations = false;
+final List<SleepNightObservation> _cardioObservations = <SleepNightObservation>[];
+
+/// Drain and clear the recorded observations (returns a copy).
+List<SleepNightObservation> takeCardioObservations() {
+  final c = List<SleepNightObservation>.of(_cardioObservations);
+  _cardioObservations.clear();
+  return c;
+}
+
+/// Clear the observation buffer without reading it.
+void resetCardioObservations() => _cardioObservations.clear();
 
 /// Transparent cardiorespiratory stager.
 ///
@@ -76,7 +253,11 @@ CardioStagerResult cardioStager(
   List<double> rrMs = const [],
   List<double> rrTsMs = const [],
   int epochSec = _epochSec,
+  SleepUserProfile? userProfile,
 }) {
+  // Explicit arg wins (unit tests); else the ambient profile the edge set for
+  // this staging pass; else null ⇒ pure per-night-local (cold-start behavior).
+  final profile = userProfile ?? cardioUserProfile;
   final n = math.min(hr1hz.length, accel.length);
   final nEpoch = n ~/ epochSec;
   if (nEpoch < 3) {
@@ -130,6 +311,14 @@ CardioStagerResult cardioStager(
   final hr = List<double>.filled(nEpoch, double.nan);
   final hrSd = List<double>.filled(nEpoch, 0);
   final rmssd = List<double>.filled(nEpoch, double.nan);
+  // REM autonomic features (P1): LF/HF from the RR spectrum + R(k) = rolling
+  // mean |ΔIHR|. REM's signature at 1 Hz beat-timing is a SYMPATHETIC shift —
+  // LF/HF rises, RR variability drops (low RMSSD), and instantaneous HR gets
+  // "jittery" (elevated |ΔIHR|). The old REM rule leaned only on the RMSSD drop
+  // and under-called REM; these two independent axes recover it (OR-combined
+  // below), gated by atonia + an HR floor so a plain arousal is not miscalled.
+  final lfhf = List<double>.filled(nEpoch, double.nan);
+  final rk = List<double>.filled(nEpoch, double.nan);
 
   for (var e = 0; e < nEpoch; e++) {
     final s = e * epochSec, t = math.min(s + epochSec, n);
@@ -147,6 +336,10 @@ CardioStagerResult cardioStager(
     if (hv.length >= 2) hrSd[e] = stddev(hv) ?? 0;
     // rmssd over RR beats within a ±2.5-min window centred on the epoch
     rmssd[e] = _windowRmssd(rrMs, rrTsMs, accel, s, t, epochSec);
+    // LF/HF + R(k) over a ±90-s RR window centred on the epoch.
+    final rem = _windowRemFeatures(rrMs, rrTsMs, accel, s, t, epochSec);
+    if (rem.lfhf != null) lfhf[e] = rem.lfhf!;
+    if (rem.rk != null) rk[e] = rem.rk!;
   }
 
   // ── night baselines (from the LOW-MOTION epochs — the actual sleep) ────────
@@ -158,13 +351,21 @@ CardioStagerResult cardioStager(
   final motSample = [for (final m in motion) m];
   final motMed = median(motSample) ?? 0;
   final motMad = (mad(motSample) ?? 0).clamp(1e-9, double.infinity);
+  // Personal-baseline blend (P2): pull each LOCAL threshold a bounded fraction
+  // toward the sleeper's rolling profile value. `_pw` (≤0.5) grows with nights,
+  // so per-night-local always leads; a null profile axis ⇒ no blend for it.
+  final double _pw = profile?.personalWeight ?? 0.0;
+  double blendP(double local, double? personal) =>
+      (personal == null || _pw == 0) ? local : local * (1 - _pw) + personal * _pw;
   // "still" (for baseline selection) = motion near the night's typical low.
-  bool still(int e) => motion[e] <= motMed + 1.5 * motMad;
+  final stillCut = blendP(motMed + 1.5 * motMad, profile?.enmoStillCut);
+  bool still(int e) => motion[e] <= stillCut;
   // "big move" = clearly elevated motion (getting up / large reposition), used
   // for the WAKE decision — a much higher bar than `still` so normal in-sleep
   // repositioning (which the van-Hees window already certified as sleep) is NOT
   // mistaken for wake.
-  bool bigMove(int e) => motion[e] > motMed + 5.0 * motMad;
+  final bigMoveCut = blendP(motMed + 5.0 * motMad, profile?.enmoMoveCut);
+  bool bigMove(int e) => motion[e] > bigMoveCut;
 
   final sleepHr = <double>[
     for (var e = 0; e < nEpoch; e++)
@@ -215,17 +416,40 @@ CardioStagerResult cardioStager(
       hrP25Local[e] = percentile(win, 25) ?? m;
     }
   }
+  // Blend the per-epoch LOCAL HR gates toward the sleeper's rolling profile.
+  if (profile != null && _pw > 0) {
+    for (var e = 0; e < nEpoch; e++) {
+      hrMedLocal[e] = blendP(hrMedLocal[e], profile.hrSleepMedian);
+      hrArousalLocal[e] = blendP(hrArousalLocal[e], profile.hrArousal);
+      hrP25Local[e] = blendP(hrP25Local[e], profile.hrFloorP25);
+    }
+  }
 
   final sleepRmssd = <double>[
     for (var e = 0; e < nEpoch; e++)
       if (still(e) && !rmssd[e].isNaN) rmssd[e]
   ];
   final rmssdMed = median(sleepRmssd);
+  // Night sleep distributions for the LF/HF and R(k) REM axes (robust-z base).
+  final sleepLfhf = <double>[
+    for (var e = 0; e < nEpoch; e++)
+      if (still(e) && !lfhf[e].isNaN) lfhf[e]
+  ];
+  final sleepRk = <double>[
+    for (var e = 0; e < nEpoch; e++)
+      if (still(e) && !rk[e].isNaN) rk[e]
+  ];
   final hrSdSample = [for (final s in hrSd) if (s > 0) s];
   final hrSdMed = median(hrSdSample) ?? double.infinity;
-  // Deep = HR in the lower half of the night's sleeping HR (the cardiac trough).
-  // Stays a whole-night comparison (not part of the diagnosed bug; unchanged).
-  final deepHrCut = hrFloor + 0.5 * (hrMedGlobal - hrFloor);
+  // RMSSD reference for the deep "not-elevated-HRV" gate, blended toward profile.
+  final rmssdRef = rmssdMed == null
+      ? profile?.rmssdMed
+      : blendP(rmssdMed, profile?.rmssdMed);
+  // Deep = HR in the lower half of the night's sleeping HR (the cardiac trough),
+  // with the floor/median blended toward the personal profile (P2).
+  final deepFloor = blendP(hrFloor, profile?.hrFloorP5);
+  final deepMed = blendP(hrMedGlobal, profile?.hrSleepMedian);
+  final deepHrCut = deepFloor + 0.5 * (deepMed - deepFloor);
 
   // ── classify ───────────────────────────────────────────────────────────────
   final stages = List<SleepStage>.filled(nEpoch, SleepStage.wake);
@@ -244,14 +468,29 @@ CardioStagerResult cardioStager(
       stages[e] = SleepStage.wake;
       continue;
     }
-    // Asleep. REM vs NREM via autonomic signature.
+    // Asleep. REM vs NREM via autonomic signature. REM is OR-combined across
+    // three independent RR axes (any one suffices), THEN gated by atonia (no
+    // large movement) AND an HR floor (HR ≥ the local p25 — REM is not the
+    // quiescent cardiac trough). This recovers REM the RMSSD-only rule missed.
     final rmZ = (rmssdMed != null && !rmssd[e].isNaN && sleepRmssd.length >= 4)
         ? robustZ(rmssd[e], sleepRmssd)
         : null;
     final rmssdDown = rmZ != null && rmZ < -0.4; // RMSSD notably below sleep base
+    // LF/HF elevated (sympathetic shift) vs the night's sleeping LF/HF.
+    final lfhfZ = (sleepLfhf.length >= 4 && !lfhf[e].isNaN)
+        ? robustZ(lfhf[e], sleepLfhf)
+        : null;
+    final lfhfHigh = lfhfZ != null && lfhfZ > _remLfhfZ;
+    // R(k) burst: instantaneous-HR variability elevated vs sleeping R(k).
+    final rkZ = (sleepRk.length >= 4 && !rk[e].isNaN)
+        ? robustZ(rk[e], sleepRk)
+        : null;
+    final rkBurst = rkZ != null && rkZ > _remRkZ;
+    final remAutonomic = rmssdDown || lfhfHigh || rkBurst;
+    final atonia = !bigMove(e); // muscle-atonia proxy — no large movement
     final hrTowardWake =
         !hr[e].isNaN && hr[e] >= hrP25Local[e]; // HR up but not arousal
-    if (rmssdDown && hrTowardWake) {
+    if (remAutonomic && atonia && hrTowardWake) {
       stages[e] = SleepStage.rem;
     } else {
       stages[e] = SleepStage.nrem;
@@ -262,16 +501,41 @@ CardioStagerResult cardioStager(
       // so deep lands in a physiologic range instead of ~0.
       final lowHr = !hr[e].isNaN && hr[e] <= deepHrCut;
       final notHighRmssd =
-          rmssdMed == null || rmssd[e].isNaN || rmssd[e] >= rmssdMed * 0.9;
+          rmssdRef == null || rmssd[e].isNaN || rmssd[e] >= rmssdRef * 0.9;
       final stable = hrSd[e] <= hrSdMed * 1.5;
       deepFlag[e] = lowHr && notHighRmssd && stable;
     }
   }
 
-  // ── post-process: Webster continuity (bridge brief arousals) + consolidate ──
+  // ── post-process: median-filter flicker → Webster continuity → consolidate ──
+  // A 3-epoch categorical median (mode) filter first, to drop isolated
+  // single-epoch label flips (e.g. a lone REM/deep spike inside a stable run)
+  // before the continuity/consolidation stages act on min bouts.
+  _modeFilterStages(stages);
   _websterRescore(stages, epochSec);
   final sm = consolidateSleepStages(stages, epochSec);
   _mergeShortDeep(deepFlag, sm, epochSec);
+
+  // ── record this night's baselines for the rolling per-user profile (P2) ─────
+  // Only when the edge armed recording AND the staged span is a real sleep
+  // (≥60 min) — naps must not pollute the sleeper's night profile.
+  if (cardioRecordObservations && nEpoch >= 120 && sleepHr.isNotEmpty) {
+    _cardioObservations.add(SleepNightObservation(
+      epochs: nEpoch,
+      hrFloorP5: percentile(sleepHr, 5),
+      hrFloorP25: percentile(sleepHr, 25),
+      hrSleepMedian: median(sleepHr),
+      hrArousal: (median(sleepHr) ?? hrMedGlobal) +
+          math.max(6.0, stddev(sleepHr) ?? 6.0),
+      rmssdMed: rmssdMed,
+      rmssdMad: mad(sleepRmssd),
+      enmoStillCut: motMed + 1.5 * motMad,
+      enmoMoveCut: motMed + 5.0 * motMad,
+      lfhfMed: median(sleepLfhf),
+      rkMed: median(sleepRk),
+    ));
+    if (_cardioObservations.length > 32) _cardioObservations.removeAt(0);
+  }
 
   // ── percentages + confidence ────────────────────────────────────────────────
   var w = 0, nr = 0, r = 0;
@@ -403,6 +667,87 @@ void _websterRescore(List<SleepStage> sm, int epochSec) {
       }
     }
     i = j;
+  }
+}
+
+/// REM autonomic features over a ±90-s RR window centred on epoch [s,t):
+///   • lfhf = LF(0.04–0.15 Hz) / HF(0.15–0.40 Hz) band-power ratio, computed on
+///     the NATIVE beat times via Lomb–Scargle (the project's validated PSD for
+///     unevenly-sampled RR — no resampling, superior to interpolating to 4 Hz).
+///   • rk   = mean |ΔIHR| over the window (IHR = 60000/RR bpm) — the R(k) REM
+///     index (instantaneous-HR "jitter" that rises in REM).
+/// Beats are cleaned with the same physiologic gate as [_windowRmssd]. Returns
+/// nulls when too few clean beats for a stable estimate.
+({double? lfhf, double? rk}) _windowRemFeatures(List<double> rrMs,
+    List<double> rrTsMs, List<AccelSample> accel, int s, int t, int epochSec) {
+  if (rrMs.isEmpty || rrTsMs.length != rrMs.length) {
+    return (lfhf: null, rk: null);
+  }
+  final mid = (s + t) ~/ 2;
+  if (mid >= accel.length) return (lfhf: null, rk: null);
+  final centreMs = accel[mid].tsMs;
+  const halfWinMs = 90 * 1000; // ±90 s per the REM feature spec
+  final lo = centreMs - halfWinMs, hi = centreMs + halfWinMs;
+  final beats = <double>[]; // clean RR (ms)
+  final beatTsSec = <double>[]; // matching beat times (s)
+  double? prev;
+  for (var i = 0; i < rrMs.length; i++) {
+    final ts = rrTsMs[i];
+    if (ts < lo || ts > hi) continue;
+    final v = rrMs[i];
+    if (v < _rrMin || v > _rrMax) {
+      prev = null;
+      continue;
+    }
+    if (prev != null && (v - prev).abs() > _rrMaxStep) {
+      prev = v;
+      continue;
+    }
+    beats.add(v);
+    beatTsSec.add(ts / 1000.0);
+    prev = v;
+  }
+  if (beats.length < 16) return (lfhf: null, rk: null); // spectral stability gate
+  // R(k): mean absolute successive difference of instantaneous HR (bpm).
+  var rkSum = 0.0;
+  var rkCnt = 0;
+  double? prevIhr;
+  for (final v in beats) {
+    final ihr = 60000.0 / v;
+    if (prevIhr != null) {
+      rkSum += (ihr - prevIhr).abs();
+      rkCnt++;
+    }
+    prevIhr = ihr;
+  }
+  final rk = rkCnt > 0 ? rkSum / rkCnt : null;
+  // LF/HF via Lomb–Scargle on native beat times.
+  double? lfhf;
+  final spanSec = beatTsSec.last - beatTsSec.first;
+  if (spanSec > 0) {
+    final loHz = (1.0 / spanSec).clamp(0.0005, 0.04);
+    final ls = lombScargle(beatTsSec, beats, freqGrid(loHz, 0.4, 240));
+    if (ls != null) {
+      final lf = ls.bandPower(0.04, 0.15);
+      final hf = ls.bandPower(0.15, 0.40);
+      if (hf > 0) lfhf = lf / hf;
+    }
+  }
+  return (lfhf: lfhf, rk: rk);
+}
+
+/// 3-epoch categorical median (mode) filter: flip a lone epoch whose two
+/// neighbours agree and differ from it. Removes single-epoch label flicker
+/// without touching runs of length ≥2. Operates in place.
+void _modeFilterStages(List<SleepStage> s) {
+  final n = s.length;
+  if (n < 3) return;
+  final out = List<SleepStage>.of(s);
+  for (var i = 1; i < n - 1; i++) {
+    if (s[i - 1] == s[i + 1] && s[i] != s[i - 1]) out[i] = s[i - 1];
+  }
+  for (var i = 0; i < n; i++) {
+    s[i] = out[i];
   }
 }
 

--- a/lib/src/onehz/sleep/cardio_stager.dart
+++ b/lib/src/onehz/sleep/cardio_stager.dart
@@ -166,6 +166,9 @@ class SleepUserProfile {
   /// adapts fast and settled profiles track the recent few weeks. A null
   /// observed field leaves that axis untouched.
   SleepUserProfile fold(SleepNightObservation o, {int horizonNights = 14}) {
+    // horizonNights <= 0 makes the 2/(N+1) alpha floor >= 1 (or divide-by-zero /
+    // negative), which over-weights the newest night and corrupts the EWMA.
+    assert(horizonNights > 0, 'horizonNights must be positive');
     final n2 = nights + 1;
     final a = math.max(1.0 / n2, 2.0 / (horizonNights + 1));
     double? ew(double? old, double? obs) =>
@@ -514,6 +517,14 @@ CardioStagerResult cardioStager(
   _modeFilterStages(stages);
   _websterRescore(stages, epochSec);
   final sm = consolidateSleepStages(stages, epochSec);
+  // Keep deepFlag in lockstep with the FINAL consolidated stage: the mode filter,
+  // Webster rescore, and consolidation can move a deep-flagged NREM epoch to REM
+  // or Wake. Clear the flag there so no epoch is ever reported deep while its
+  // stage disagrees (_mergeShortDeep only skips non-NREM epochs — it never
+  // clears a stale flag left on one).
+  for (var e = 0; e < deepFlag.length && e < sm.length; e++) {
+    if (deepFlag[e] && sm[e] != SleepStage.nrem) deepFlag[e] = false;
+  }
   _mergeShortDeep(deepFlag, sm, epochSec);
 
   // ── record this night's baselines for the rolling per-user profile (P2) ─────
@@ -725,7 +736,7 @@ void _websterRescore(List<SleepStage> sm, int epochSec) {
   double? lfhf;
   final spanSec = beatTsSec.last - beatTsSec.first;
   if (spanSec > 0) {
-    final loHz = (1.0 / spanSec).clamp(0.0005, 0.04);
+    final loHz = (1.0 / spanSec).clamp(0.0005, 0.04).toDouble();
     final ls = lombScargle(beatTsSec, beats, freqGrid(loHz, 0.4, 240));
     if (ls != null) {
       final lf = ls.bandPower(0.04, 0.15);

--- a/test/onehz/sleep_user_profile_test.dart
+++ b/test/onehz/sleep_user_profile_test.dart
@@ -1,0 +1,116 @@
+// P2 — per-user rolling sleep profile: EWMA fold, JSON round-trip, cold-start
+// blend weight, and that a stored profile is bounded (never dominant) inside
+// the stager.
+import 'package:test/test.dart';
+import 'package:openstrap_analytics/onehz.dart';
+
+void main() {
+  group('SleepUserProfile', () {
+    test('cold start: no nights ⇒ zero personal weight (pure per-night-local)',
+        () {
+      expect(const SleepUserProfile().personalWeight, 0.0);
+      expect(const SleepUserProfile(nights: 0).personalWeight, 0.0);
+    });
+
+    test('personal weight grows with nights and hard-caps at 0.5', () {
+      expect(const SleepUserProfile(nights: 7).personalWeight, closeTo(0.25, 1e-9));
+      expect(const SleepUserProfile(nights: 14).personalWeight, 0.5);
+      expect(const SleepUserProfile(nights: 40).personalWeight, 0.5);
+    });
+
+    test('first fold takes the observation whole (alpha=1)', () {
+      const base = SleepUserProfile();
+      final o = const SleepNightObservation(
+        epochs: 700,
+        hrFloorP5: 50,
+        hrSleepMedian: 58,
+        rmssdMed: 40,
+      );
+      final p = base.fold(o);
+      expect(p.nights, 1);
+      expect(p.hrFloorP5, 50);
+      expect(p.hrSleepMedian, 58);
+      expect(p.rmssdMed, 40);
+    });
+
+    test('subsequent folds EWMA toward new observations, absent axis untouched',
+        () {
+      var p = const SleepUserProfile().fold(
+        const SleepNightObservation(epochs: 700, hrSleepMedian: 60, rmssdMed: 40),
+      );
+      // Second night: higher HR median, and NO rmssd observed this night.
+      p = p.fold(const SleepNightObservation(epochs: 700, hrSleepMedian: 70));
+      // alpha at n2=2 is max(1/2, 2/15)=0.5 → 60*0.5 + 70*0.5 = 65.
+      expect(p.hrSleepMedian, closeTo(65, 1e-9));
+      // rmssd had no new observation → retained from night 1.
+      expect(p.rmssdMed, 40);
+      expect(p.nights, 2);
+    });
+
+    test('EWMA alpha floors at ~2/(N+1) for settled profiles', () {
+      var p = const SleepUserProfile();
+      for (var i = 0; i < 30; i++) {
+        p = p.fold(const SleepNightObservation(epochs: 700, hrSleepMedian: 60));
+      }
+      // A single deviating night barely moves a settled profile.
+      final q = p.fold(const SleepNightObservation(epochs: 700, hrSleepMedian: 90));
+      final a = 2.0 / (14 + 1);
+      expect(q.hrSleepMedian, closeTo(60 * (1 - a) + 90 * a, 1e-6));
+    });
+
+    test('JSON round-trips and omits null axes', () {
+      final p = const SleepUserProfile().fold(
+        const SleepNightObservation(
+          epochs: 700,
+          hrFloorP5: 50,
+          hrFloorP25: 55,
+          hrSleepMedian: 60,
+          hrArousal: 72,
+          enmoStillCut: 0.01,
+          enmoMoveCut: 0.05,
+          lfhfMed: 1.2,
+          rkMed: 3.4,
+        ),
+      );
+      final j = p.toJson();
+      expect(j.containsKey('rmssd_med'), isFalse); // never observed ⇒ omitted
+      final back = SleepUserProfile.fromJson(j);
+      expect(back.nights, p.nights);
+      expect(back.hrFloorP5, 50);
+      expect(back.hrArousal, 72);
+      expect(back.lfhfMed, 1.2);
+      expect(back.rmssdMed, isNull);
+    });
+
+    test('a profile consistent with the night does not destabilize staging',
+        () {
+      // Synthetic still, low-HR night (should read as overwhelmingly asleep).
+      const n = 4 * 3600; // 4 h at 1 Hz
+      final hr = List<double>.filled(n, 55.0);
+      final accel = <AccelSample>[
+        for (var i = 0; i < n; i++) AccelSample(i * 1000.0, 0, 0, 1.0),
+      ];
+      final noProfile = cardioStager(hr, accel).base;
+      // A profile whose baselines AGREE with this night (median ~55, a plausibly
+      // higher arousal, a lower floor). At max personal weight (0.5) the blend
+      // must not turn a clean sleep night into wake.
+      final benign = const SleepUserProfile(
+        nights: 40, // personalWeight = 0.5 (max)
+        hrSleepMedian: 55,
+        hrArousal: 75,
+        hrFloorP25: 50,
+        hrFloorP5: 48,
+      );
+      final withProfile = cardioStager(hr, accel, userProfile: benign).base;
+      // Both stay overwhelmingly asleep — the bounded blend is safe here.
+      expect(noProfile.wakePct, lessThan(20.0));
+      expect(withProfile.wakePct, lessThan(20.0));
+      // Sanity: the blend actually shifted SOMETHING vs a no-op (or matched it).
+      expect(
+        (withProfile.wakePct - noProfile.wakePct).abs(),
+        lessThan(50.0),
+        reason: 'a consistent profile must not swing staging wildly',
+      );
+    });
+  });
+}

--- a/test/onehz/sleep_user_profile_test.dart
+++ b/test/onehz/sleep_user_profile_test.dart
@@ -108,7 +108,7 @@ void main() {
       // Sanity: the blend actually shifted SOMETHING vs a no-op (or matched it).
       expect(
         (withProfile.wakePct - noProfile.wakePct).abs(),
-        lessThan(50.0),
+        lessThan(5.0),
         reason: 'a consistent profile must not swing staging wildly',
       );
     });


### PR DESCRIPTION
This pull request introduces major improvements to the sleep staging algorithm, focusing on REM detection accuracy and user personalization. The changes add new autonomic features for REM detection, implement a rolling per-user sleep profile for personalized threshold blending, and enhance post-processing to reduce stage flicker. The updates are designed to improve sensitivity to REM without sacrificing specificity and to make the algorithm adapt over time to each user's sleep patterns.

**Key changes include:**

### REM Detection Improvements
- Added two new secondary REM detection axes: LF/HF elevation and R(k) burst, using robust-z scoring. These axes recover REM that the primary RMSSD rule misses, improving detection accuracy while maintaining specificity. [[1]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR62-R242) [[2]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR314-R321) [[3]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR339-R342) [[4]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cL247-R493) [[5]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR673-R753)
- Implemented the `_windowRemFeatures` function to extract LF/HF and R(k) features from RR intervals using Lomb–Scargle PSD and instantaneous HR variability.

### Personalization (Per-User Sleep Profile)
- Introduced the `SleepUserProfile` class to store and blend rolling per-user sleep baselines (e.g., HR, RMSSD, motion thresholds) with per-night-local values, improving adaptation to individual sleep patterns. [[1]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR62-R242) [[2]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR256-R260) [[3]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR354-R368) [[4]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR419-R452)
- Added mechanisms to record nightly sleep observations (`SleepNightObservation`), fold them into the user profile, and blend profile values into nightly thresholds, with a capped influence to preserve local adaptation. [[1]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR62-R242) [[2]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR419-R452) [[3]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cL265-R539)

### Post-processing Enhancements
- Added a 3-epoch categorical median (mode) filter to remove single-epoch stage flicker before continuity and consolidation steps, resulting in smoother and more reliable stage sequences. [[1]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cL265-R539) [[2]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR673-R753)

### Other Algorithmic Refinements
- Adjusted the min-session floor logic in `AdvancedSleepStager` to exempt night-tail continuations from the 60-min minimum, ensuring genuine fragmented sleep is not truncated.
- Blended deep sleep HR and RMSSD thresholds toward the user profile for more robust and personalized deep sleep detection. [[1]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cR419-R452) [[2]](diffhunk://#diff-e45f06577d68b3f916a8f406292e6931dd6a1875b46811a9f1621823f2fea52cL265-R539)

These updates significantly improve both the accuracy and personalization of sleep staging, especially for REM and deep sleep detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added personalized sleep staging using a persisted, rolling per-user baseline.
  * Enhanced REM/deep-sleep detection with additional autonomic features derived from heart-rate dynamics and motion thresholds blended from local statistics.
  * Added support for capturing, reviewing, and resetting nightly sleep observations.

* **Bug Fixes**
  * Refined continuation handling so short night-tail segments are conditionally accepted without weakening the rest of the sleep-segment validation pipeline.

* **Tests**
  * Added a dedicated test suite for sleep user profile behavior, folding/serialization, and an integration-style staging stability check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->