### PR TITLE
readiness: mean/SD z fallback when robust (MAD) z is degenerate

### DIFF
--- a/lib/src/onehz/wellness/readiness_composite.dart
+++ b/lib/src/onehz/wellness/readiness_composite.dart
@@ -108,7 +108,14 @@ Metric<Readiness> readinessComposite(
       if (base.length > bestShortHave) bestShortHave = base.length;
       continue;
     }
-    final zr = robustZ(v, base); // null if MAD degenerate
+    // Robust z (median + MAD) first. But a QUANTIZED input (whole-bpm RHR,
+    // integer skin-temp ADC) can cluster tight enough on some nights that MAD
+    // collapses to 0 — robustZ then returns null and, if that was the only
+    // present input, the WHOLE score intermittently blanked to "—" (present some
+    // nights, absent others, even with sleep detected). Fall back to an ordinary
+    // mean/SD z so a usable input still contributes; only skip when SD is ALSO
+    // zero (a truly constant baseline with no dispersion to normalize against).
+    final zr = robustZ(v, base) ?? z(v, base);
     if (zr == null) continue;
     final oriented = inp.goodSign * zr; // + = good for readiness
     used.add(inp.label);

--- a/test/onehz/wellness_test.dart
+++ b/test/onehz/wellness_test.dart
@@ -292,6 +292,27 @@ void main() {
       // unused local to keep the analyzer quiet about `base`.
       expect(base.length, 14);
     });
+
+    test('degenerate-MAD baseline is rescued by mean/SD z (no intermittent "—")',
+        () {
+      // A quantized RHR whose recent baseline clusters tight enough that the
+      // median-absolute-deviation collapses to 0 (deviations from the median 52
+      // are [0,0,0,0,0,0,1] => MAD 0), but SD > 0. robustZ can't score this, so
+      // before the fallback the WHOLE composite blanked to "—" here — the
+      // intermittent "readiness sometimes disappears (with sleep present)" bug.
+      final tightBase = <double>[52, 52, 52, 52, 52, 52, 53];
+      final m = readinessComposite([rhrInput(56.0, tightBase)]);
+      expect(m.present, isTrue,
+          reason: 'mean/SD z should rescue a MAD==0 (but SD>0) baseline');
+      expect(m.inputs_used, ['RHR']);
+      // RHR well above a tight baseline => bad for readiness => below 50.
+      expect(m.value!.score, lessThan(50));
+
+      // A TRULY constant baseline (SD == 0 too) still honestly abstains — we
+      // only rescue degenerate MAD, never fabricate against zero dispersion.
+      final flat = readinessComposite([rhrInput(56.0, <double>[52, 52, 52, 52])]);
+      expect(flat.present, isFalse);
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Symptom
Readiness intermittently renders `—` — a score some days, blank others — **even on nights with a detected sleep session**, and re-analyze doesn't reliably fix it.

## Root cause
`readinessComposite` z-scores each input against its personal baseline with **median + MAD** (`robustZ`), which returns `null` when **MAD == 0**. Readiness inputs are quantized (whole-bpm nocturnal RHR, integer skin-temp ADC), so a tightly-clustered recent baseline (e.g. RHR `52,52,52,53` → MAD 0) makes `robustZ` degenerate on *some* nights. When that happens to the only present input, the whole composite abstains → intermittent `—`. It's data-dependent and run-to-run unstable, which is why it looked random.

## Fix
```dart
final zr = robustZ(v, base) ?? z(v, base);
```
Fall back to an ordinary mean/SD z when the robust z is degenerate. Still abstains only when SD is **also** 0 (a truly constant baseline with no dispersion — never fabricated against zero variance). This **only adds coverage on nights that were previously `—`; it never changes an existing score.**

## Tests
- New regression test in `wellness_test.dart` covering the `52,52,52,53` degenerate-MAD case (now present) and the SD==0 constant baseline (still honestly absent).
- Full analytics suite green (290/290).

## Downstream
Edge bumps `kAlgoVersion 42→43` so previously-blanked days recompute. **Merge this first**, then re-pin edge's `pubspec.lock` to the new analytics `main` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness scoring for quantized inputs when robust baseline calculations are unavailable.
  * Readiness can now remain available when standard deviation provides a valid fallback.
  * Fully constant baselines continue to be excluded when no meaningful variation exists.

* **Tests**
  * Added regression coverage for degenerate baseline scenarios and readiness availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->