### PR TITLE
fix(stager): rebase REM LF/HF beat times off absolute epoch (kills v42 ANR trig slow-path)

### DIFF
--- a/lib/src/onehz/sleep/cardio_stager.dart
+++ b/lib/src/onehz/sleep/cardio_stager.dart
@@ -715,7 +715,15 @@ void _websterRescore(List<SleepStage> sm, int epochSec) {
       continue;
     }
     beats.add(v);
-    beatTsSec.add(ts / 1000.0);
+    // Rebase to the window start (lo), NOT absolute epoch ms. Lomb–Scargle is
+      // time-shift invariant (the τ phase reference cancels any offset), so the
+      // LF/HF output is unchanged — but this keeps beat times in [0, 180] s
+      // instead of ~1.75e9 s. Absolute epoch seconds force every sin/cos in the
+      // periodogram onto libm's __kernel_rem_pio2 multi-precision slow path
+      // (args ~9e9 rad), which — run per 30-s epoch over a full night on the
+      // main isolate — caused main-thread ANRs on Android (Crashlytics: libm.so
+      // __kernel_rem_pio2 / sin / cos, 0.9.13).
+      beatTsSec.add((ts - lo) / 1000.0);
     prev = v;
   }
   if (beats.length < 16) return (lfhf: null, rk: null); // spectral stability gate


### PR DESCRIPTION
## What
`_windowRemFeatures` fed **absolute epoch seconds** (~1.75e9) into the per-30 s-epoch Lomb–Scargle. With `w = 2π·0.4`, arguments hit ~9×10⁹ rad, forcing every `sin`/`cos` onto libm's `__kernel_rem_pio2` multi-precision slow path — tens of millions of slow-path trig calls over a full night.

## Fix
Rebase beat times to the window start (`(ts - lo)/1000`), keeping them in `[0, 180] s`. Lomb–Scargle is **time-shift invariant** (the τ phase reference cancels any offset), so LF/HF output is unchanged in exact arithmetic (only last-ULP float differences).

## Impact
~10× faster staging pass; removes the per-epoch trig cost behind the v42 main-thread ANRs on Android (Crashlytics 0.9.13: `libm.so __kernel_rem_pio2 / sin / cos`).

## Verification
- `dart test` → **289/289 pass**, including the real-night cardio-stager ground-truth regression (staging output unchanged).
- Audited the other `lombScargle` call sites (`cpc`, `resp_rate` rsaRespRate, `cardiac_coherence`, `hrv_freq`) — all fed cumulative `nnTimesMs` (start ~0), so they're safe. `riivRespRate` takes caller-supplied `tsSec` but has no callers (latent only).

Paired with edge PR (kAlgoVersion bump + staging moved off the main isolate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sleep cardio analysis by using local time references for spectral calculations within each analysis window.
  * No changes were made to staging thresholds, results interfaces, or other public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->