### PR TITLE
fix(readiness): keep absent breakdowns JSON-safe

### DIFF
--- a/lib/src/onehz/human/readiness_glassbox.dart
+++ b/lib/src/onehz/human/readiness_glassbox.dart
@@ -63,7 +63,8 @@ class ReadinessBreakdownItem {
   });
   Map<String, dynamic> toJson() => {
         'label': label,
-        'percentile_of_you': round6(percentileOfYou),
+        'percentile_of_you':
+            percentileOfYou.isFinite ? round6(percentileOfYou) : null,
         'weight': round6(weight),
         'weighted_contribution': round6(weightedContribution),
         'past_mdc': pastMdc,

--- a/test/onehz/human_test.dart
+++ b/test/onehz/human_test.dart
@@ -306,9 +306,11 @@ void main() {
       final m = glassBoxReadiness(inputs);
       expect(m.present, isTrue);
       expect(m.value!.inputsUsed, 1);
-      // breakdown still lists temp, marked unused.
+      // breakdown still lists temp, marked unused and JSON-safe.
       final temp = m.value!.breakdown.firstWhere((b) => b.label == 'temp');
       expect(temp.used, isFalse);
+      expect(temp.toJson()['percentile_of_you'], isNull);
+      expect(() => jsonEncode(m.toJson((v) => v.toJson())), returnsNormally);
     });
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness result serialization when percentile values are unavailable.
  * Readiness breakdown entries now omit unavailable percentile data instead of producing invalid JSON.
  * Complete readiness results can now be safely encoded as JSON when inputs are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->