### PR TITLE
the stager stopped doing the same work three times

### DIFF
--- a/lib/src/onehz/sleep/cardio_stager.dart
+++ b/lib/src/onehz/sleep/cardio_stager.dart
@@ -674,11 +674,14 @@ CardioStagerResult classifyCardioEpochs(
       for (var k = lo; k < hi; k++)
         if (still(k) && !hr[k].isNaN) hr[k]
     ];
-    final m = median(win);
+    // One sort for both percentiles of this 361-epoch window (stddev doesn't
+    // care about order). `win` is freshly built here, so sorting it is local.
+    win.sort();
+    final m = percentileSorted(win, 50);
     if (m != null) {
       hrMedLocal[e] = m;
       hrArousalLocal[e] = m + math.max(6.0, (stddev(win) ?? 6));
-      hrP25Local[e] = percentile(win, 25) ?? m;
+      hrP25Local[e] = percentileSorted(win, 25) ?? m;
     }
   }
   // Blend the per-epoch LOCAL HR gates toward the sleeper's rolling profile.
@@ -872,13 +875,14 @@ CardioStagerResult classifyCardioEpochs(
   // Only when the edge armed recording AND the staged span is a real sleep
   // (≥60 min) — naps must not pollute the sleeper's night profile.
   if (cardioRecordObservations && nEpoch >= 120 && sleepHr.isNotEmpty) {
+    final hrSleepMed = median(sleepHr);
     _cardioObservations.add(SleepNightObservation(
       epochs: nEpoch,
       hrFloorP5: percentile(sleepHr, 5),
       hrFloorP25: percentile(sleepHr, 25),
-      hrSleepMedian: median(sleepHr),
-      hrArousal: (median(sleepHr) ?? hrMedGlobal) +
-          math.max(6.0, stddev(sleepHr) ?? 6.0),
+      hrSleepMedian: hrSleepMed,
+      hrArousal:
+          (hrSleepMed ?? hrMedGlobal) + math.max(6.0, stddev(sleepHr) ?? 6.0),
       rmssdMed: rmssdMed,
       rmssdMad: mad(sleepRmssd),
       enmoStillCut: motMed + 1.5 * motMad,

--- a/lib/src/onehz/sleep/cardio_stager.dart
+++ b/lib/src/onehz/sleep/cardio_stager.dart
@@ -950,30 +950,7 @@ CardioStagerResult _abstain(int epochSec) => CardioStagerResult(
 /// window centred on epoch [s,t). Returns NaN when too few clean beats.
 double _windowRmssd(List<double> rrMs, List<double> rrTsMs,
     List<AccelSample> accel, int s, int t, int epochSec) {
-  if (rrMs.isEmpty || rrTsMs.length != rrMs.length) return double.nan;
-  final mid = (s + t) ~/ 2;
-  if (mid >= accel.length) return double.nan;
-  final centreMs = accel[mid].tsMs;
-  const halfWinMs = 150 * 1000; // ±2.5 min for a stable RMSSD on sparse RR
-  final lo = centreMs - halfWinMs, hi = centreMs + halfWinMs;
-  // Gather clean beats in window (300–2000 ms, drop big successive jumps).
-  final beats = <double>[];
-  double? prev;
-  for (var i = 0; i < rrMs.length; i++) {
-    final ts = rrTsMs[i];
-    if (ts < lo || ts > hi) continue;
-    final v = rrMs[i];
-    if (v < _rrMin || v > _rrMax) {
-      prev = null;
-      continue;
-    }
-    if (prev != null && (v - prev).abs() > _rrMaxStep) {
-      prev = v;
-      continue;
-    }
-    beats.add(v);
-    prev = v;
-  }
+  final beats = _cleanBeatsInWindow(rrMs, rrTsMs, accel, s, t).beats;
   if (beats.length < 5) return double.nan;
   var ss = 0.0;
   for (var i = 1; i < beats.length; i++) {
@@ -995,7 +972,7 @@ double _windowRmssd(List<double> rrMs, List<double> rrTsMs,
 /// flat RMSSD of 67.3 / 70.7 / 79.7.
 double _windowSdnn(List<double> rrMs, List<double> rrTsMs,
     List<AccelSample> accel, int s, int t, int epochSec) {
-  final beats = _cleanBeatsInWindow(rrMs, rrTsMs, accel, s, t);
+  final beats = _cleanBeatsInWindow(rrMs, rrTsMs, accel, s, t).beats;
   if (beats.length < 5) return double.nan;
   final m = mean(beats)!;
   var ss = 0.0;
@@ -1005,18 +982,33 @@ double _windowSdnn(List<double> rrMs, List<double> rrTsMs,
   return math.sqrt(ss / (beats.length - 1));
 }
 
-/// Clean RR beats (ms) inside the ±2.5-min window centred on epoch [s,t).
-/// Shared by [_windowRmssd] and [_windowSdnn] so both see exactly the same
-/// beats — a divergence there would make their z-scores incomparable.
-List<double> _cleanBeatsInWindow(List<double> rrMs, List<double> rrTsMs,
-    List<AccelSample> accel, int s, int t) {
-  if (rrMs.isEmpty || rrTsMs.length != rrMs.length) return const <double>[];
+/// Clean RR beats (ms) inside a ±[halfWinMs] window centred on epoch [s,t),
+/// with each beat's time rebased to the window start (seconds).
+///
+/// The physiologic gate (300–2000 ms, drop big successive jumps) lives here and
+/// only here, so every window feature sees exactly the same beats for a given
+/// window — [_windowRmssd] and [_windowSdnn] are computed over one window and
+/// must agree on its contents.
+///
+/// [_windowRemFeatures] passes a DIFFERENT [halfWinMs] on purpose (±90 s, not
+/// ±2.5 min): its LF/HF grid and its `beats.length` abstain gate are specified
+/// against that shorter window. Do not hand it the default list.
+({List<double> beats, List<double> tsSec}) _cleanBeatsInWindow(
+  List<double> rrMs,
+  List<double> rrTsMs,
+  List<AccelSample> accel,
+  int s,
+  int t, {
+  int halfWinMs = 150 * 1000,
+}) {
+  const empty = (beats: <double>[], tsSec: <double>[]);
+  if (rrMs.isEmpty || rrTsMs.length != rrMs.length) return empty;
   final mid = (s + t) ~/ 2;
-  if (mid >= accel.length) return const <double>[];
+  if (mid >= accel.length) return empty;
   final centreMs = accel[mid].tsMs;
-  const halfWinMs = 150 * 1000;
   final lo = centreMs - halfWinMs, hi = centreMs + halfWinMs;
   final beats = <double>[];
+  final tsSec = <double>[];
   double? prev;
   for (var i = 0; i < rrMs.length; i++) {
     final ts = rrTsMs[i];
@@ -1031,9 +1023,18 @@ List<double> _cleanBeatsInWindow(List<double> rrMs, List<double> rrTsMs,
       continue;
     }
     beats.add(v);
+    // Rebase to the window start (lo), NOT absolute epoch ms. Lomb–Scargle is
+    // time-shift invariant (the τ phase reference cancels any offset), so the
+    // LF/HF output is unchanged — but this keeps beat times in [0, 180] s
+    // instead of ~1.75e9 s. Absolute epoch seconds force every sin/cos in the
+    // periodogram onto libm's __kernel_rem_pio2 multi-precision slow path
+    // (args ~9e9 rad), which — run per 30-s epoch over a full night on the
+    // main isolate — caused main-thread ANRs on Android (Crashlytics: libm.so
+    // __kernel_rem_pio2 / sin / cos, 0.9.13).
+    tsSec.add((ts - lo) / 1000.0);
     prev = v;
   }
-  return beats;
+  return (beats: beats, tsSec: tsSec);
 }
 
 /// Webster sleep-continuity rescore: brief wake bouts flanked by enough sleep
@@ -1135,41 +1136,12 @@ void _websterRescore(List<SleepStage> sm, int epochSec) {
 /// nulls when too few clean beats for a stable estimate.
 ({double? lfhf, double? rk}) _windowRemFeatures(List<double> rrMs,
     List<double> rrTsMs, List<AccelSample> accel, int s, int t, int epochSec) {
-  if (rrMs.isEmpty || rrTsMs.length != rrMs.length) {
-    return (lfhf: null, rk: null);
-  }
-  final mid = (s + t) ~/ 2;
-  if (mid >= accel.length) return (lfhf: null, rk: null);
-  final centreMs = accel[mid].tsMs;
-  const halfWinMs = 90 * 1000; // ±90 s per the REM feature spec
-  final lo = centreMs - halfWinMs, hi = centreMs + halfWinMs;
-  final beats = <double>[]; // clean RR (ms)
-  final beatTsSec = <double>[]; // matching beat times (s)
-  double? prev;
-  for (var i = 0; i < rrMs.length; i++) {
-    final ts = rrTsMs[i];
-    if (ts < lo || ts > hi) continue;
-    final v = rrMs[i];
-    if (v < _rrMin || v > _rrMax) {
-      prev = null;
-      continue;
-    }
-    if (prev != null && (v - prev).abs() > _rrMaxStep) {
-      prev = v;
-      continue;
-    }
-    beats.add(v);
-    // Rebase to the window start (lo), NOT absolute epoch ms. Lomb–Scargle is
-    // time-shift invariant (the τ phase reference cancels any offset), so the
-    // LF/HF output is unchanged — but this keeps beat times in [0, 180] s
-    // instead of ~1.75e9 s. Absolute epoch seconds force every sin/cos in the
-    // periodogram onto libm's __kernel_rem_pio2 multi-precision slow path
-    // (args ~9e9 rad), which — run per 30-s epoch over a full night on the
-    // main isolate — caused main-thread ANRs on Android (Crashlytics: libm.so
-    // __kernel_rem_pio2 / sin / cos, 0.9.13).
-    beatTsSec.add((ts - lo) / 1000.0);
-    prev = v;
-  }
+  // ±90 s per the REM feature spec — a DIFFERENT window from the RMSSD/SDNN
+  // one; see [_cleanBeatsInWindow].
+  final win = _cleanBeatsInWindow(rrMs, rrTsMs, accel, s, t,
+      halfWinMs: 90 * 1000);
+  final beats = win.beats; // clean RR (ms)
+  final beatTsSec = win.tsSec; // matching beat times (s), rebased to window
   if (beats.length < 16)
     return (lfhf: null, rk: null); // spectral stability gate
   // R(k): mean absolute successive difference of instantaneous HR (bpm).

--- a/lib/src/onehz/sleep/cardio_stager.dart
+++ b/lib/src/onehz/sleep/cardio_stager.dart
@@ -675,13 +675,20 @@ CardioStagerResult classifyCardioEpochs(
       for (var k = lo; k < hi; k++)
         if (still(k) && !hr[k].isNaN) hr[k]
     ];
-    // One sort for both percentiles of this 361-epoch window (stddev doesn't
-    // care about order). `win` is freshly built here, so sorting it is local.
+    // BEFORE the sort, and that is not fussiness: `stddev` sums `(x-m)^2` in
+    // list order and mean sums in list order too, so re-ordering the window
+    // changes the last bits of both. Algebraically order-free, in float it is
+    // not, and this feeds `hrArousalLocal` — which decides wake epochs near the
+    // threshold. Computing it here keeps this refactor bit-identical, which is
+    // the whole contract of the change.
+    final sd = stddev(win);
+    // One sort for both percentiles of this 361-epoch window. `win` is freshly
+    // built here, so sorting it is local.
     win.sort();
     final m = percentileSorted(win, 50);
     if (m != null) {
       hrMedLocal[e] = m;
-      hrArousalLocal[e] = m + math.max(6.0, (stddev(win) ?? 6));
+      hrArousalLocal[e] = m + math.max(6.0, (sd ?? 6));
       hrP25Local[e] = percentileSorted(win, 25) ?? m;
     }
   }

--- a/lib/src/onehz/sleep/cardio_stager.dart
+++ b/lib/src/onehz/sleep/cardio_stager.dart
@@ -366,8 +366,9 @@ void resetCardioObservations() => _cardioObservations.clear();
 /// [hr1hz] per-second HR (bpm; 0 = off-skin) over the in-bed window.
 /// [accel] per-second gravity vectors, SAME length/time base as [hr1hz].
 /// [rrMs] / [rrTsMs] beat-to-beat RR (ms) and their ABSOLUTE times (ms), same
-///   clock as `accel[i].tsMs`. Sparse/empty is fine — REM/deep just lean more on
-///   HR and confidence drops.
+///   clock as `accel[i].tsMs`, ASCENDING in [rrTsMs] (the per-epoch window
+///   gather lower-bounds into it). Sparse/empty is fine — REM/deep just lean
+///   more on HR and confidence drops.
 CardioStagerResult cardioStager(
   List<double> hr1hz,
   List<AccelSample> accel, {
@@ -1011,12 +1012,28 @@ double _windowSdnn(List<double> rrMs, List<double> rrTsMs,
   if (mid >= accel.length) return empty;
   final centreMs = accel[mid].tsMs;
   final lo = centreMs - halfWinMs, hi = centreMs + halfWinMs;
+  // [rrTsMs] is ascending, so lower-bound into it and stop at the far edge
+  // instead of walking every beat of the night once per epoch per feature.
+  //
+  // TRUE lower bound — the first index with ts >= lo, NOT the first index
+  // strictly greater than lo. `rr_ts_ms` is `rec_ts * 1000`, so beats TIE on
+  // the second boundary; dropping the tied beats at a window edge changes
+  // RMSSD / SDNN / LF-HF and with them the REM and deep epoch counts, silently.
+  var a = 0, b = rrTsMs.length;
+  while (a < b) {
+    final m = (a + b) >> 1;
+    if (rrTsMs[m] < lo) {
+      a = m + 1;
+    } else {
+      b = m;
+    }
+  }
   final beats = <double>[];
   final tsSec = <double>[];
   double? prev;
-  for (var i = 0; i < rrMs.length; i++) {
+  for (var i = a; i < rrMs.length; i++) {
     final ts = rrTsMs[i];
-    if (ts < lo || ts > hi) continue;
+    if (ts > hi) break;
     final v = rrMs[i];
     if (v < _rrMin || v > _rrMax) {
       prev = null;
@@ -1040,6 +1057,19 @@ double _windowSdnn(List<double> rrMs, List<double> rrTsMs,
   }
   return (beats: beats, tsSec: tsSec);
 }
+
+/// [_cleanBeatsInWindow]'s beats, exposed so the window-edge regression test
+/// can drive the gather directly. Not a staging entry point — call
+/// [cardioStager].
+List<double> cleanBeatsInWindowForTest(
+  List<double> rrMs,
+  List<double> rrTsMs,
+  List<AccelSample> accel,
+  int s,
+  int t, {
+  int halfWinMs = 150 * 1000,
+}) =>
+    _cleanBeatsInWindow(rrMs, rrTsMs, accel, s, t, halfWinMs: halfWinMs).beats;
 
 /// Webster sleep-continuity rescore: brief wake bouts flanked by enough sleep
 /// are re-labelled sleep (NREM). This is the published actigraphy step that

--- a/lib/src/onehz/sleep/cardio_stager.dart
+++ b/lib/src/onehz/sleep/cardio_stager.dart
@@ -382,6 +382,19 @@ CardioStagerResult cardioStager(
   // Explicit arg wins (unit tests); else the ambient profile the edge set for
   // this staging pass; else null ⇒ pure per-night-local (cold-start behavior).
   final profile = userProfile ?? cardioUserProfile;
+  // `_cleanBeatsInWindow` binary-searches this, so it has to be non-decreasing.
+  // The producer guarantees it — beats inherit their record's second and the
+  // records are sorted, and the one path that folds in loose live beats
+  // re-sorts the pair explicitly. An `assert` rather than a linear fallback:
+  // a fallback would pay the scan back on every window to insure against a
+  // state the caller cannot reach, whereas this is free in release and loud in
+  // every test the moment somebody builds an unsorted series.
+  assert(() {
+    for (var i = 1; i < rrTsMs.length; i++) {
+      if (rrTsMs[i] < rrTsMs[i - 1]) return false;
+    }
+    return true;
+  }(), 'rrTsMs must be non-decreasing — the beat window is binary-searched');
   final n = math.min(hr1hz.length, accel.length);
   final nEpoch = n ~/ epochSec;
   if (nEpoch < 3) return _abstain(epochSec);

--- a/lib/src/onehz/util.dart
+++ b/lib/src/onehz/util.dart
@@ -40,10 +40,14 @@ double? stddevPop(List<double> xs) {
   return math.sqrt(s / xs.length);
 }
 
-/// Linear-interpolated percentile (p in [0,100]); null if empty.
-double? percentile(List<double> values, double p) {
-  if (values.isEmpty) return null;
-  final sorted = [...values]..sort();
+/// Linear-interpolated percentile (p in [0,100]) of an ALREADY-ASCENDING list;
+/// null if empty. For when you hold a sorted list already, or want several
+/// percentiles of one window without re-sorting it each time.
+///
+/// Null on empty, never 0 — a 0.0 is a measurement, and an empty window is the
+/// absence of one.
+double? percentileSorted(List<double> sorted, double p) {
+  if (sorted.isEmpty) return null;
   if (sorted.length == 1) return sorted[0];
   final rank = (p / 100) * (sorted.length - 1);
   final lo = rank.floor();
@@ -52,6 +56,10 @@ double? percentile(List<double> values, double p) {
   final frac = rank - lo;
   return sorted[lo] + (sorted[hi] - sorted[lo]) * frac;
 }
+
+/// Linear-interpolated percentile (p in [0,100]); null if empty.
+double? percentile(List<double> values, double p) =>
+    percentileSorted([...values]..sort(), p);
 
 /// Median (linear-interpolated), or null if empty.
 double? median(List<double> xs) => percentile(xs, 50);

--- a/test/onehz/real_night_cardio_stager_test.dart
+++ b/test/onehz/real_night_cardio_stager_test.dart
@@ -45,6 +45,8 @@ import 'package:test/test.dart';
 import 'package:openstrap_analytics/onehz.dart';
 
 void main() {
+  _windowEdgeTies();
+
   test('cardioStager on the real 2026-07 overnight capture matches Apple '
       'Watch ground truth within a wide band (regression: was wake=294min '
       'rem=41min pre-fix)', () {
@@ -133,5 +135,39 @@ void main() {
     // Sanity: the four buckets still account for the whole session.
     final tot = wakeMin + lightMin + deepMin + remMin;
     expect(tot, closeTo(stages.length * epochMin, 0.01));
+  });
+}
+
+// The per-epoch RR window is found by binary search. `rr_ts_ms` is
+// `rec_ts * 1000`, so beat timestamps TIE — several beats share one second,
+// and a second boundary can land exactly on a window edge. The search must be
+// a TRUE lower bound (first index >= lo) and the far edge must be inclusive;
+// "first index strictly greater than lo" drops the tied beats at the edge,
+// which moves RMSSD / SDNN / LF-HF and with them the REM and deep counts.
+void _windowEdgeTies() {
+  test('window gather keeps tied beats at BOTH edges', () {
+    final accel = <AccelSample>[
+      for (var i = 0; i < 30; i++) AccelSample(i * 1000.0, 0, 0, 1)
+    ];
+    // epoch [0,30) -> mid 15 -> centre 15000 ms; ±5 s -> window [10000, 20000].
+    final ts = <double>[
+      9000, // just before -> out
+      10000, 10000, 10000, // tie ON the low edge -> in
+      15000,
+      20000, 20000, 20000, // tie ON the high edge -> in
+      21000, // just after -> out
+    ];
+    final rr = <double>[for (var i = 0; i < ts.length; i++) 900.0];
+
+    final beats =
+        cleanBeatsInWindowForTest(rr, ts, accel, 0, 30, halfWinMs: 5000);
+    // 7, not 4 (low ties dropped) and not 5 (both edges exclusive).
+    expect(beats.length, 7);
+
+    // and the beats really are the in-window ones, in order.
+    final marked = <double>[900, 901, 902, 903, 904, 905, 906, 907, 908];
+    final got =
+        cleanBeatsInWindowForTest(marked, ts, accel, 0, 30, halfWinMs: 5000);
+    expect(got, [901, 902, 903, 904, 905, 906, 907]);
   });
 }

--- a/test/onehz/util_test.dart
+++ b/test/onehz/util_test.dart
@@ -16,6 +16,15 @@ void main() {
       expect(stddev([5]), isNull);
     });
 
+    test('percentileSorted matches percentile and stays null on empty', () {
+      final sorted = [1.0, 2.0, 3.0, 4.0];
+      expect(percentileSorted(sorted, 50), percentile(sorted, 50));
+      expect(percentileSorted(sorted, 25), percentile(sorted, 25));
+      expect(percentileSorted([7.0], 25), 7.0);
+      // NOT 0 — an empty window is no measurement, not a 0 bpm floor.
+      expect(percentileSorted([], 25), isNull);
+    });
+
     test('MAD and robust z; MAD=0 guard on quantized data', () {
       // [1,1,1,1,1] -> median 1, MAD 0 => robustZ null (not div-by-zero).
       expect(mad([1, 1, 1, 1, 1], scaled: false), 0);


### PR DESCRIPTION
Stacked on #48. Output must be **bit-identical** — there is no `kAlgoVersion` bump in this PR, and if one becomes necessary the change is wrong.

An optimizer pass went through the tree arguing for deletion; every claim it made was then handed to a separate agent that did not know who made it and was told to assume it was wrong. These three survived that. One claim elsewhere was refuted outright — structurally accurate, but its proposal was slower than the code it replaced.

## the safety argument

The real-night gate asserts wide bands (`wakeMin < 35`, `remMin > 100`) and would not have noticed a small move, so the numbers were pinned directly instead:

```
epochs=1068  wake=52  rem=300  nrem=716  deep=137  light=579  conf=0.5501404494382023
```

Identical after all three commits, confidence to the last digit.

## what changed

**`_windowRmssd` and `_windowRemFeatures` each hand-copied `_cleanBeatsInWindow`**, which is the function whose own docstring promises the invariant they were breaking. Folded back in; `_cleanBeatsInWindow` takes `halfWinMs` now. REM keeps its own 90 s window and the docstring says why, so nobody "simplifies" that later — handing it the ±150 s list re-spaces the Lomb–Scargle grid, defeats the `beats.length < 16` abstain gate, and re-opens a previously fixed ANR. The stale rationale in that docstring is corrected too: rmssd is not z-scored any more.

**The rolling HR baseline sorted the same 361-epoch window twice**, about 25 lines below a comment congratulating itself on not doing that. `percentileSorted` split out of `percentile`, window sorted in place once, duplicated `median(sleepHr)` hoisted. `percentileSorted` keeps the nullable contract — there are two `_percentileSorted` copies in this repo that return `0` on empty and they stay where they are; a 0-on-empty percentile beside a null-on-empty one is how a 0.0 bpm floor gets recorded as a measured baseline.

**Two window scans are binary searches now.** True lower bound, per call, no cursor threaded through the epoch loop — `centreMs` comes from `accel`, not `rrTsMs`, so a cross-epoch cursor would assume monotonicity nothing promises.

**The tie trap is pinned by a test, not a comment.** `rr_ts_ms` is `rec_ts * 1000`, so beat timestamps tie. Writing the search the natural way — first index strictly greater — fails the new test 7 → 4 **and moves the real night**: `deep 137 → 132`, `light 579 → 584`. That mutation is now caught.

## measured

`cardioStager` on the full real night: **~950 ms → ~805 ms, about 15%** (medians of 6 and 5 runs). The original claim implied ~200x; Lomb–Scargle's trig dominates and is untouched. The commit messages carry the measured figure, not the claimed one.

580 tests, analyze clean.

## deliberately not done

Deduping the two `_percentileSorted` copies. Hoisting the gather out of `_windowRmssd`/`_windowSdnn` to the epoch loop — it would halve that work again but changes two signatures. A runtime sorted-ness guard on `rrTsMs`, which would cost what the search saves; the requirement is documented instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sleep cardio analysis by correctly handling ascending RR timestamps and rolling-window boundaries.
  - Ensured heart-rate and recovery metrics use consistent, efficient window calculations.
  - Preserved accurate percentile behavior, including empty data windows.

- **Tests**
  - Added regression coverage for RR values on and outside window boundaries.
  - Added percentile calculation coverage for sorted, single-value, and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->