### PR TITLE
fix irregular rhythm screen firing almost every day

### DIFF
--- a/lib/src/onehz/clinical/irregular_rhythm.dart
+++ b/lib/src/onehz/clinical/irregular_rhythm.dart
@@ -56,12 +56,25 @@ const int irregularScreenMinBeats = 500;
 /// to flag. Returns an absent Metric when there are too few clean beats.
 Metric<IrregularRhythm> irregularBeatScreen(
   List<double> rrMs, {
+  // Elapsed beat time (ms), same length + index alignment as [rrMs] — e.g.
+  // `RrCorrectionResult.nnTimesMs`. Used ONLY to require the irregularity be
+  // SUSTAINED across independent short windows rather than true of one number
+  // blended across the whole span. Optional for backward compatibility, but
+  // pass it whenever [rrMs] spans more than a few minutes of heterogeneous
+  // activity (a whole day) — see the sustained-window note below.
+  List<double>? nnTimesMs,
   double artifactFraction = 0.0,
   int minBeats = irregularScreenMinBeats,
   double sd1sd2Flag = 0.70,
   double pnnThresholdMs = 70,
   double pnnFlagPct = 30,
   double maxArtifact = 0.30,
+  // ponytail: fixed 5-min / 50%-of-windows heuristic, not backtested against
+  // labeled arrhythmia data (none available) — upgrade path is to calibrate
+  // windowMinutes/sustainedFraction once real AFib-vs-sinus recordings exist.
+  double windowMinutes = 5,
+  int minWindowBeats = 40,
+  double sustainedFraction = 0.5,
 }) {
   const inputs = ['rr_cleaned'];
   // The defensive [300, 2000] filter COMPACTS the series. Keep the mask too, so
@@ -125,7 +138,30 @@ Metric<IrregularRhythm> irregularBeatScreen(
   }
   final pnnPct = diffs.isEmpty ? 0.0 : 100.0 * over / diffs.length;
 
-  final flag = ratio >= sd1sd2Flag && pnnPct >= pnnFlagPct;
+  final aggregateHigh = ratio >= sd1sd2Flag && pnnPct >= pnnFlagPct;
+  // A single ratio blended across an entire day always clears both cutoffs —
+  // sleep, rest, exercise and posture changes are each legitimately
+  // "scattered" in a different way, and stacking them together manufactures
+  // the appearance of sustained irregularity out of ordinary daily
+  // variability (validated on real user data: 9/9 sampled days sat at or
+  // over BOTH thresholds, flagged or not — see analytics#irregular-rhythm
+  // false-positive fix). Require the same two conditions to independently
+  // hold in a real fraction of short, mostly-stationary windows instead —
+  // that is what "sustained" is supposed to mean. Falls back to the old
+  // whole-span verdict only when times weren't supplied (short/sleep-only
+  // callers where the whole span already IS roughly one physiological state).
+  final flag = aggregateHigh &&
+      (nnTimesMs == null ||
+          _sustainedAcrossWindows(
+            rrMs,
+            nnTimesMs,
+            sd1sd2Flag: sd1sd2Flag,
+            pnnThresholdMs: pnnThresholdMs,
+            pnnFlagPct: pnnFlagPct,
+            windowMinutes: windowMinutes,
+            minWindowBeats: minWindowBeats,
+            sustainedFraction: sustainedFraction,
+          ));
   // Confidence scales with beat count (~5000 beats ≈ a full strong night) AND
   // with the artifact fraction we were handed — it used to ignore it entirely,
   // so a barely-passing 29 %-artifact night published at the same confidence as
@@ -147,4 +183,59 @@ Metric<IrregularRhythm> irregularBeatScreen(
         '${pnnThresholdMs.round()}. PRV not ECG — wrist pulse misses P-waves. '
         'Discuss with a clinician only if you have symptoms.',
   );
+}
+
+/// True when the SD1/SD2 + pNNx criteria independently hold in a real
+/// fraction of short, roughly-stationary windows across [rrMs] — not just in
+/// the one number the whole span blends into. [timesMs] must be the same
+/// length as [rrMs] and index-aligned (elapsed ms per beat).
+bool _sustainedAcrossWindows(
+  List<double> rrMs,
+  List<double> timesMs, {
+  required double sd1sd2Flag,
+  required double pnnThresholdMs,
+  required double pnnFlagPct,
+  required double windowMinutes,
+  required int minWindowBeats,
+  required double sustainedFraction,
+}) {
+  if (timesMs.length != rrMs.length || rrMs.length < 2) return false;
+  final windowMs = windowMinutes * 60000;
+  var windowStart = timesMs.first;
+  var validWindows = 0;
+  var flaggedWindows = 0;
+  var bucket = <double>[];
+  void flush() {
+    if (bucket.length >= minWindowBeats) {
+      validWindows++;
+      final diffs = <double>[
+        for (var i = 1; i < bucket.length; i++) bucket[i] - bucket[i - 1]
+      ];
+      final sdsd = stddev(diffs);
+      final sdnn = stddev(bucket);
+      if (sdsd != null && sdnn != null) {
+        final sd1 = sdsd / math.sqrt2;
+        final v = 2 * sdnn * sdnn - sd1 * sd1;
+        final sd2 = v > 0 ? math.sqrt(v) : 0.0;
+        if (sd2 > 0) {
+          final ratio = sd1 / sd2;
+          final over = diffs.where((d) => d.abs() > pnnThresholdMs).length;
+          final pnn = 100.0 * over / diffs.length;
+          if (ratio >= sd1sd2Flag && pnn >= pnnFlagPct) flaggedWindows++;
+        }
+      }
+    }
+    bucket = [];
+  }
+
+  for (var i = 0; i < rrMs.length; i++) {
+    if (timesMs[i] - windowStart >= windowMs) {
+      flush();
+      windowStart = timesMs[i];
+    }
+    bucket.add(rrMs[i]);
+  }
+  flush();
+  if (validWindows == 0) return false;
+  return flaggedWindows / validWindows >= sustainedFraction;
 }

--- a/lib/src/onehz/clinical/irregular_rhythm.dart
+++ b/lib/src/onehz/clinical/irregular_rhythm.dart
@@ -150,11 +150,19 @@ Metric<IrregularRhythm> irregularBeatScreen(
   // that is what "sustained" is supposed to mean. Falls back to the old
   // whole-span verdict only when times weren't supplied (short/sleep-only
   // callers where the whole span already IS roughly one physiological state).
+  // Windows are built from the SAME clean beats as the aggregate above (the
+  // [keep] mask), not the raw input — an artifact beat the aggregate
+  // correctly excludes must not be allowed back in here to inflate one
+  // window's own ratio/pNN into a spurious per-window flag.
+  final hasTimes = nnTimesMs != null && nnTimesMs.length == rrMs.length;
+  final nnTimes = hasTimes
+      ? [for (var i = 0; i < rrMs.length; i++) if (keep[i]) nnTimesMs[i]]
+      : const <double>[];
   final flag = aggregateHigh &&
-      (nnTimesMs == null ||
+      (!hasTimes ||
           _sustainedAcrossWindows(
-            rrMs,
-            nnTimesMs,
+            nn,
+            nnTimes,
             sd1sd2Flag: sd1sd2Flag,
             pnnThresholdMs: pnnThresholdMs,
             pnnFlagPct: pnnFlagPct,
@@ -200,6 +208,16 @@ bool _sustainedAcrossWindows(
   required double sustainedFraction,
 }) {
   if (timesMs.length != rrMs.length || rrMs.length < 2) return false;
+  // Fail CLOSED (never sustained) on a bad config — a misconfigured caller
+  // must never manufacture a medical false positive.
+  if (!windowMinutes.isFinite ||
+      windowMinutes <= 0 ||
+      minWindowBeats < 2 ||
+      !sustainedFraction.isFinite ||
+      sustainedFraction < 0 ||
+      sustainedFraction > 1) {
+    return false;
+  }
   final windowMs = windowMinutes * 60000;
   var windowStart = timesMs.first;
   var validWindows = 0;

--- a/test/onehz/irregular_rhythm_test.dart
+++ b/test/onehz/irregular_rhythm_test.dart
@@ -93,6 +93,36 @@ void main() {
       expect(withTimes.value!.flag, isFalse);
     });
 
+    test('out-of-range artifact beats sprinkled through organised windows '
+        'do not fake a per-window flag', () {
+      // Every 6th beat is a hard-implausible outlier (>2000 ms) — the same
+      // [keep] mask the aggregate uses must also apply to the windowed pass,
+      // or these get counted as real successive-diff jumps inside a window.
+      final organised = <double>[
+        for (var i = 0; i < 3600; i++)
+          i % 6 == 5 ? 5000.0 : 900 + 15 * math.sin(i / 8)
+      ];
+      final times = <double>[];
+      var t = 0.0;
+      for (final v in organised) {
+        t += v;
+        times.add(t);
+      }
+      final m = irregularBeatScreen(organised, nnTimesMs: times);
+      expect(m.value!.flag, isFalse);
+    });
+
+    test('mismatched nnTimesMs length falls back to the whole-span verdict '
+        'instead of crashing', () {
+      final rnd = math.Random(7);
+      final rr = <double>[
+        for (var i = 0; i < 1200; i++)
+          800.0 + (rnd.nextBool() ? 250 : -50) + rnd.nextInt(120)
+      ];
+      final m = irregularBeatScreen(rr, nnTimesMs: [1.0, 2.0, 3.0]);
+      expect(m.value!.flag, isTrue);
+    });
+
     test('scatter sustained across (nearly) the whole day still flags with '
         'sustained-window times', () {
       final rnd = math.Random(7);

--- a/test/onehz/irregular_rhythm_test.dart
+++ b/test/onehz/irregular_rhythm_test.dart
@@ -42,5 +42,72 @@ void main() {
       expect(m.present, isFalse);
       expect(m.note, contains('artifact'));
     });
+
+    // Regression for the real-world false positive: a day built mostly of
+    // organised stretches with two short, fast (many-beats-per-minute, e.g.
+    // an exercise episode) scattered stretches blends into a whole-span
+    // ratio that clears both thresholds, even though only 2 of 12 real
+    // 5-minute windows were ever irregular — see the fix note in
+    // irregular_rhythm.dart. Beat count and elapsed time are deliberately
+    // decoupled here (each block gets a fixed 5-minute time slot regardless
+    // of how many beats it holds) — exactly what a fast episode does for
+    // real: more beats land in the same wall-clock window.
+    test('scatter confined to 2 of 12 windows does NOT flag once '
+        'sustained-window times are supplied, though the blend does', () {
+      final rnd = math.Random(7);
+      List<double> organised(int n) =>
+          [for (var i = 0; i < n; i++) 900 + 15 * math.sin(i / 8)];
+      List<double> scattered(int n) => [
+            for (var i = 0; i < n; i++)
+              800.0 + (rnd.nextDouble() < 0.5 ? 250 : -50) + rnd.nextInt(120)
+          ];
+      final orgBlocks = [for (var i = 0; i < 10; i++) organised(300)];
+      final scatBlocks = [for (var i = 0; i < 2; i++) scattered(1800)];
+      final blocks = [
+        ...orgBlocks.sublist(0, 5),
+        scatBlocks[0],
+        ...orgBlocks.sublist(5),
+        scatBlocks[1],
+      ];
+      final rr = [for (final b in blocks) ...b];
+
+      const windowMs = 5 * 60000.0;
+      final times = <double>[];
+      var windowStart = 0.0;
+      for (final b in blocks) {
+        for (var i = 0; i < b.length; i++) {
+          times.add(windowStart + (i / b.length) * windowMs * 0.999);
+        }
+        windowStart += windowMs;
+      }
+
+      // Without times: falls back to the old whole-span verdict (still flags
+      // — this is exactly the bug being fixed).
+      final withoutTimes = irregularBeatScreen(rr);
+      expect(withoutTimes.value!.flag, isTrue);
+      expect(withoutTimes.value!.pnnPct, greaterThanOrEqualTo(30));
+
+      // With times: only 2 of 12 real 5-minute windows are irregular — not
+      // sustained — so the day must not flag.
+      final withTimes = irregularBeatScreen(rr, nnTimesMs: times);
+      expect(withTimes.value!.flag, isFalse);
+    });
+
+    test('scatter sustained across (nearly) the whole day still flags with '
+        'sustained-window times', () {
+      final rnd = math.Random(7);
+      final rr = <double>[
+        for (var i = 0; i < 1200; i++)
+          800.0 + (rnd.nextBool() ? 250 : -50) + rnd.nextInt(120)
+      ];
+      final times = <double>[];
+      var t = 0.0;
+      for (final v in rr) {
+        t += v;
+        times.add(t);
+      }
+      final m = irregularBeatScreen(rr, nnTimesMs: times);
+      expect(m.value!.flag, isTrue);
+    });
   });
 }


### PR DESCRIPTION
the 24/7 irregular-rhythm screen blended one SD1/SD2 + pNN70 ratio across a whole day (sleep + rest + exercise + everything mixed in). checked a real export and every single day sat right at/over both cutoffs, flagged or not — normal daily variability alone clears them once you blend a whole day into one number.

now it also requires the same two conditions to hold in a real fraction of short 5-min windows, not just once in the blend. strictly stricter, can only turn a false flag off, never on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced irregular-rhythm screening with optional timestamp-based analysis across configurable time windows.
  * Results now reflect whether irregularity is sustained across enough valid windows, reducing isolated-event flags.
  * Existing whole-span screening behavior remains available when timestamps are not provided.

* **Tests**
  * Added coverage for distinguishing brief irregular episodes from irregularity sustained throughout the day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->