### PR TITLE
fix hr ceiling missing uneven-motion holds + kill duplicate clamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ pile of textbook equations. What comes out of here is an honest approximation bu
 exactly what the band hands over, nothing more. It trends correctly, it'll tell you when
 you're under-recovered — it's not their secret sauce, and it never claims to be.
 
+## Where this fits
+
+Three repos, one pipeline:
+
+- [**protocol**](https://github.com/OpenStrap/protocol) — decodes the raw bytes off the
+  band into the 1 Hz records this package consumes.
+- **analytics** (this repo) — the math above: records in, metrics out.
+- [**edge**](https://github.com/OpenStrap/edge) — storage, sync, Bluetooth, and the UI
+  that calls this package and shows you the numbers.
+
+A byte-level change (a new record, an opcode) belongs in `protocol`; see
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full breakdown.
+
 ## How a number knows how much to trust itself
 
 Almost everything returns the same shape — `Metric<T>`. (A handful of multi-day/list
@@ -110,7 +123,8 @@ not a feature, no matter how tempting the plausible-looking headline is.
 dart test   # run from the repo root — some fixtures resolve paths relative to it
 ```
 
-290 tests, nothing mocked — pure functions, fixture in, assertion out.
+Nothing mocked — pure functions, fixture in, assertion out. See the badge above for the
+current pass/fail count.
 
 ## If you want to add a metric
 

--- a/lib/src/onehz/clinical/cardiac_coherence.dart
+++ b/lib/src/onehz/clinical/cardiac_coherence.dart
@@ -128,11 +128,7 @@ Metric<CardiacCoherence> cardiacCoherence(
   // this span actually covers (floored/ceilinged), lightly penalized when the
   // found peak isn't near the guided pace (could still be real RSA, just less
   // clearly the paced-breathing entrainment this feature is meant to reward).
-  final conf = clamp(
-    (spanSec / 180.0).clamp(0.3, 1.0) * (onPace ? 1.0 : 0.85),
-    0.2,
-    0.9,
-  );
+  final conf = ((spanSec / 180.0).clamp(0.3, 1.0) * (onPace ? 1.0 : 0.85)).clamp(0.2, 0.9);
 
   return Metric<CardiacCoherence>(
     value: CardiacCoherence(ratio: ratio, score: score, peakHz: peakHz),

--- a/lib/src/onehz/clinical/cosinor.dart
+++ b/lib/src/onehz/clinical/cosinor.dart
@@ -124,14 +124,14 @@ Metric<CosinorFit> cosinor(
     ssTot += (y[i] - yMean) * (y[i] - yMean);
     ssRes += (y[i] - fit) * (y[i] - fit);
   }
-  final r2 = ssTot == 0 ? 0.0 : clamp(1 - ssRes / ssTot, 0, 1);
+  final r2 = ssTot == 0 ? 0.0 : (1 - ssRes / ssTot).clamp(0, 1).toDouble();
   // Adjusted for the 3 fitted parameters (M, β, γ). Confidence MUST come from
   // the adjusted value: the raw R² of a 3-parameter fit is upward-biased
   // (E[R²] = 2/(n−1) under the null), so a handful of noise points used to
   // score confidence 0.95 at tier HIGH.
-  final r2Adj = clamp(1 - (1 - r2) * (n - 1) / (n - 3), 0, 1);
+  final r2Adj = (1 - (1 - r2) * (n - 1) / (n - 3)).clamp(0, 1).toDouble();
 
-  final conf = clamp(r2Adj, 0.1, 0.95);
+  final conf = r2Adj.clamp(0.1, 0.95).toDouble();
   return Metric<CosinorFit>(
     value: CosinorFit(
       mesor: mesor,

--- a/lib/src/onehz/clinical/hrv_freq.dart
+++ b/lib/src/onehz/clinical/hrv_freq.dart
@@ -150,7 +150,7 @@ Metric<HrvFreq> hrvFreq(
       : [for (final b in resolved) bands[b]!].reduce((a, b) => a + b);
 
   // Confidence: penalize artifacts heavily; low-band-only reads still HIGH-ish.
-  final conf = clamp((1 - artifactFraction) * (hfGated ? 0.6 : 0.9), 0.2, 0.9);
+  final conf = ((1 - artifactFraction) * (hfGated ? 0.6 : 0.9)).clamp(0.2, 0.9);
   return Metric<HrvFreq>(
     value: HrvFreq(
       ulf: ulf,

--- a/lib/src/onehz/clinical/hrv_time.dart
+++ b/lib/src/onehz/clinical/hrv_time.dart
@@ -76,7 +76,7 @@ double? nnDiffAcf1(List<List<double>> diffRuns) {
 /// falling linearly to 0 at [kNnDiffAcf1Floor] so confidence bottoms out
 /// exactly where RMSSD is refused. 1.0 when ACF1 could not be measured.
 double _acf1Quality(double? acf1) =>
-    acf1 == null ? 1.0 : clamp(1 - acf1 / kNnDiffAcf1Floor, 0.0, 1.0);
+    acf1 == null ? 1.0 : (1 - acf1 / kNnDiffAcf1Floor).clamp(0.0, 1.0);
 
 String _jitterNote(double acf1) =>
     'rmssd_refused:acf1=${acf1.toStringAsFixed(3)} — the NN successive '
@@ -200,14 +200,10 @@ Metric<HrvTime> hrvTime(
   // were ~pure noise. The beat-count term is capped BEFORE the quality terms
   // multiply it; multiplying first let an all-night beat count (n/250 ≈ 100)
   // swallow any penalty and re-clamp to 0.95 regardless.
-  final conf = clamp(
-    clamp(nnMs.length / 250.0, 0.0, 1.0) // ~250 beats ≈ 5 min
+  final conf = ((nnMs.length / 250.0).clamp(0.0, 1.0) // ~250 beats ≈ 5 min
         *
         _acf1Quality(acf1) *
-        (1 - artifactFraction),
-    0.3,
-    0.95,
-  );
+        (1 - artifactFraction)).clamp(0.3, 0.95);
   return Metric<HrvTime>(
     value: HrvTime(
       rmssd: rmssd,
@@ -341,11 +337,10 @@ Metric<double> nocturnalRmssd(
   final robust = median(rmssds)!;
   // Confidence scales with how many windows we could median over, and with the
   // measured jitter level (see [kNnDiffAcf1Floor]).
-  final conf = clamp(
-    clamp(rmssds.length / 12.0, 0.0, 1.0) * _acf1Quality(acf1), // 12 ≈ 1 h
-    0.3,
-    0.95,
-  );
+  final conf = ((rmssds.length / 12.0).clamp(0.0, 1.0) // 12 ≈ 1 h
+          *
+          _acf1Quality(acf1))
+      .clamp(0.3, 0.95);
   return Metric<double>(
     value: robust,
     confidence: conf,
@@ -452,11 +447,7 @@ Metric<double> sleepSessionWindowedRmssd(
   }
 
   final meanRmssd = mean(rmssds)!;
-  final conf = clamp(
-    clamp(rmssds.length / 12.0, 0.0, 1.0) * _acf1Quality(acf1),
-    0.3,
-    0.95,
-  );
+  final conf = ((rmssds.length / 12.0).clamp(0.0, 1.0) * _acf1Quality(acf1)).clamp(0.3, 0.95);
   return Metric<double>(
     value: meanRmssd,
     confidence: conf,

--- a/lib/src/onehz/clinical/irregular_rhythm.dart
+++ b/lib/src/onehz/clinical/irregular_rhythm.dart
@@ -174,7 +174,7 @@ Metric<IrregularRhythm> irregularBeatScreen(
   // with the artifact fraction we were handed — it used to ignore it entirely,
   // so a barely-passing 29 %-artifact night published at the same confidence as
   // a clean one.
-  final conf = clamp(nn.length / 5000.0 * (1 - artifactFraction), 0.2, 0.9);
+  final conf = (nn.length / 5000.0 * (1 - artifactFraction)).clamp(0.2, 0.9);
   return Metric<IrregularRhythm>(
     value: IrregularRhythm(
       sd1: sd1,

--- a/lib/src/onehz/clinical/load_trimp.dart
+++ b/lib/src/onehz/clinical/load_trimp.dart
@@ -687,7 +687,7 @@ Metric<LoadState> ctlAtlTsb(List<double> dailyTrimp,
     ctl = ctl + lc * (dailyTrimp[i] - ctl);
     atl = atl + la * (dailyTrimp[i] - atl);
   }
-  final conf = clamp(dailyTrimp.length / 42.0, 0.3, 0.85);
+  final conf = (dailyTrimp.length / 42.0).clamp(0.3, 0.85);
   return Metric<LoadState>(
     value: LoadState(ctl, atl, ctl - atl),
     confidence: conf,

--- a/lib/src/onehz/clinical/nocturnal.dart
+++ b/lib/src/onehz/clinical/nocturnal.dart
@@ -128,7 +128,7 @@ Metric<NocturnalRhr> nocturnalRhr(List<double> hr,
   // Confidence is COVERAGE IN SECONDS, not a sample count — 480 samples of a
   // 60 s band is the same 8 h of night as 28,800 samples at 1 Hz.
   final conf =
-      clamp(valid.length * cadence / 7200.0, 0.4, 0.95); // ~2 h => high
+      (valid.length * cadence / 7200.0).clamp(0.4, 0.95); // ~2 h => high
   return Metric<NocturnalRhr>(
     value: NocturnalRhr(best, p1, valid.length),
     confidence: conf,
@@ -189,7 +189,7 @@ Metric<HrDip> hrDip(List<double> dayHr, List<double> nightHr,
   }
   final dip = (dm - nm) / dm * 100;
   final band = dip >= 10 ? 'dipper' : (dip >= 0 ? 'non_dipper' : 'riser');
-  final conf = clamp((dv.length + nv.length) / 14400.0, 0.4, 0.9);
+  final conf = ((dv.length + nv.length) / 14400.0).clamp(0.4, 0.9);
   return Metric<HrDip>(
     value: HrDip(dip, dm, nm, band),
     confidence: conf,

--- a/lib/src/onehz/clinical/prsa.dart
+++ b/lib/src/onehz/clinical/prsa.dart
@@ -137,7 +137,7 @@ Metric<PrsaResult> _prsa(
   final xm2 = profile[l - 2]; // k=-2
   final capacity = (x0 + x1 - xm1 - xm2) / 4;
 
-  final conf = clamp(anchors.length / 1000.0, 0.3, 0.95);
+  final conf = (anchors.length / 1000.0).clamp(0.3, 0.95);
   return Metric<PrsaResult>(
     value: PrsaResult(
       capacity: capacity,

--- a/lib/src/onehz/clinical/readiness_lnrmssd.dart
+++ b/lib/src/onehz/clinical/readiness_lnrmssd.dart
@@ -115,7 +115,7 @@ Metric<ReadinessLnRmssd> readinessLnRmssd(
   final saturation =
       meanNnTodayMs != null && meanNnTodayMs > 1100 && z != null && z > 1.0;
 
-  final conf = clamp(priorWindow.length / windowDays.toDouble(), 0.3, 0.9);
+  final conf = (priorWindow.length / windowDays.toDouble()).clamp(0.3, 0.9);
   return Metric<ReadinessLnRmssd>(
     value: ReadinessLnRmssd(
       lnRmssdToday: today,

--- a/lib/src/onehz/clinical/stress_si.dart
+++ b/lib/src/onehz/clinical/stress_si.dart
@@ -104,7 +104,7 @@ Metric<StressIndex> baevskyStressIndex(List<double> nnMs,
       amoPct: (median(amos) ?? 0),
       mxdmnS: (median(ranges) ?? 0),
     ),
-    confidence: clamp(0.4 + sis.length / 60.0, 0.4, 0.7),
+    confidence: (0.4 + sis.length / 60.0).clamp(0.4, 0.7),
     tier: Tier.estimate,
     inputs_used: inputs,
     note: 'Baevsky Stress Index — median of ~5-min-window SI '

--- a/lib/src/onehz/human/associations.dart
+++ b/lib/src/onehz/human/associations.dart
@@ -870,7 +870,7 @@ Metric<AssociationScan> scanAssociations({
     // Deliberately capped low and never a function of how strong the findings
     // look. This is one person's uncontrolled observational history; more of it
     // buys a little confidence, and nothing buys a lot.
-    confidence: clamp(0.20 + 0.20 * (span / 365.0), 0.20, 0.45),
+    confidence: (0.20 + 0.20 * (span / 365.0)).clamp(0.20, 0.45),
     tier: Tier.estimate,
     inputs_used: inputs,
     note: 'association only, in your own history — never cause. lag is derived '

--- a/lib/src/onehz/human/circadian_lifestyle.dart
+++ b/lib/src/onehz/human/circadian_lifestyle.dart
@@ -143,8 +143,7 @@ Metric<SocialJetlag> socialJetlag(
     );
   }
   final sjl = _circDiffH(msf, msw); // signed shortest arc, (−12, +12]
-  final conf = clamp(
-      (freeMidSleepH.length + workMidSleepH.length) / 14.0, 0.3, 0.9);
+  final conf = ((freeMidSleepH.length + workMidSleepH.length) / 14.0).clamp(0.3, 0.9);
   return Metric<SocialJetlag>(
     value: SocialJetlag(
         sjl, sjl.abs(), msf, msw, freeMidSleepH.length, workMidSleepH.length),
@@ -260,7 +259,7 @@ Metric<Chronotype> chronotype(
 
   return Metric<Chronotype>(
     value: Chronotype(msfSc, label, stability),
-    confidence: clamp(totalDaysObserved / 28.0, 0.3, 0.9),
+    confidence: (totalDaysObserved / 28.0).clamp(0.3, 0.9),
     tier: Tier.high,
     inputs_used: inputs,
     note: 'MSFsc chronotype label (direction only, no absolute minutes)',

--- a/lib/src/onehz/human/event_detection.dart
+++ b/lib/src/onehz/human/event_detection.dart
@@ -232,7 +232,7 @@ Metric<EventState> alcoholNightFlag(
       signsPresent: signs,
       ambiguous: ambiguous,
     ),
-    confidence: clamp(signs / 4.0, 0.2, 0.85),
+    confidence: (signs / 4.0).clamp(0.2, 0.85),
     tier: Tier.high,
     inputs_used: inputs,
     note: note,
@@ -267,7 +267,7 @@ Metric<RoughNight> roughNight(EventState ev) {
           : 'a typical night for you');
   return Metric<RoughNight>(
     value: RoughNight(rough, ev.signsPresent, descriptor),
-    confidence: clamp(ev.signsPresent / 4.0, 0.2, 0.8),
+    confidence: (ev.signsPresent / 4.0).clamp(0.2, 0.8),
     tier: Tier.relative,
     inputs_used: inputs,
     note: 'neutral state descriptor — never attributes a cause',

--- a/lib/src/onehz/human/percentile_of_you.dart
+++ b/lib/src/onehz/human/percentile_of_you.dart
@@ -71,7 +71,7 @@ Metric<PercentileOfYou> percentileOfYou(
   final pct = 100.0 * (below + 0.5 * equal) / history.length;
   final label = _bandLabel(pct, better);
   // Confidence grows with history depth (more of your own data => sturdier CDF).
-  final conf = clamp(history.length / 60.0, 0.3, 0.95);
+  final conf = (history.length / 60.0).clamp(0.3, 0.95);
   return Metric<PercentileOfYou>(
     value: PercentileOfYou(value, pct, history.length, label),
     confidence: conf,
@@ -170,7 +170,7 @@ Metric<RecordCheck> personalRecord(
       margin: beats,
       mdc: gate,
     ),
-    confidence: clamp(history.length / 60.0, 0.3, 0.9),
+    confidence: (history.length / 60.0).clamp(0.3, 0.9),
     tier: Tier.relative,
     inputs_used: inputs,
     note: 'record only if it beats your prior extreme by > MDC',

--- a/lib/src/onehz/human/readiness_glassbox.dart
+++ b/lib/src/onehz/human/readiness_glassbox.dart
@@ -218,7 +218,7 @@ Metric<GlassBoxReadiness> glassBoxReadiness(
     );
   }
 
-  final score = clamp(wpsum / wsum, 0, 100);
+  final score = (wpsum / wsum).clamp(0, 100).toDouble();
 
   // Drivers ranked by |contribution|; only NAME a driver past the SWC.
   final ranked = [...raw]..sort((a, b) => b.c.abs().compareTo(a.c.abs()));
@@ -235,7 +235,7 @@ Metric<GlassBoxReadiness> glassBoxReadiness(
   final narrative = _buildNarrative(score, drivers);
 
   // Confidence reflects how many of the priority inputs were usable.
-  final conf = clamp(nUsable / inputs.length.toDouble(), 0.3, 0.9);
+  final conf = (nUsable / inputs.length.toDouble()).clamp(0.3, 0.9);
   return Metric<GlassBoxReadiness>(
     value: GlassBoxReadiness(score, items, drivers, narrative, nUsable),
     confidence: conf,

--- a/lib/src/onehz/human/sleep_regularity.dart
+++ b/lib/src/onehz/human/sleep_regularity.dart
@@ -89,7 +89,7 @@ Metric<SleepDebt> sleepDebt(
   final debt = osd - habitual;
   return Metric<SleepDebt>(
     value: SleepDebt(osd, habitual, debt, true),
-    confidence: clamp(freeNightSleepH.length / 5.0, 0.3, 0.85),
+    confidence: (freeNightSleepH.length / 5.0).clamp(0.3, 0.85),
     tier: Tier.high,
     inputs_used: inputs,
     note: 'p75 of your unconstrained nights vs your habitual night — a '

--- a/lib/src/onehz/human/weekday_effect.dart
+++ b/lib/src/onehz/human/weekday_effect.dart
@@ -249,7 +249,7 @@ Metric<WeekdayEffect> weekdayEffect(
       // stapled to it.
       meaningful: omnibusP <= alpha && peakP <= alpha,
     ),
-    confidence: clamp(0.25 + 0.25 * (span / 365.0), 0.25, 0.5),
+    confidence: (0.25 + 0.25 * (span / 365.0)).clamp(0.25, 0.5),
     tier: Tier.estimate,
     inputs_used: inputs,
     note: 'descriptive weekday split, Kruskal-Wallis omnibus then a '

--- a/lib/src/onehz/motion/energy_fusion.dart
+++ b/lib/src/onehz/motion/energy_fusion.dart
@@ -48,7 +48,6 @@
 // ---------------------------------------------------------------------------
 
 import '../types.dart';
-import '../util.dart';
 
 /// Per-sample fused energy estimate.
 class EnergyPoint {
@@ -90,10 +89,10 @@ double _normHr(double hr, double? restingHr, double? maxHr) {
   if (hr <= 0) return 0.0;
   if (restingHr != null && maxHr != null && maxHr > restingHr) {
     final hrr = (hr - restingHr) / (maxHr - restingHr);
-    return clamp(hrr, 0.0, 1.0);
+    return hrr.clamp(0.0, 1.0);
   }
   final v = (hr - 50.0) / (180.0 - 50.0);
-  return clamp(v, 0.0, 1.0);
+  return v.clamp(0.0, 1.0);
 }
 
 /// Branched HR-accel energy fusion over time-aligned 1 Hz HR + ENMO samples.
@@ -156,13 +155,13 @@ Metric<EnergyFusion> branchedEnergyFusion(
     }
     var idx = wA * a + (1 - wA) * (hValid ? h : 0.0);
     if (branch == 'transient') idx *= 0.7; // discount artifact-prone motion
-    idx = clamp(idx, 0.0, 1.0);
+    idx = idx.clamp(0.0, 1.0);
     load += idx;
     pts.add(EnergyPoint(tsMs[i], idx, a, hValid ? h : 0.0, wA, branch));
   }
   // confidence: data coverage × (calibration bonus)
   final cov = usable / n;
-  final conf = clamp(cov * (calibrated ? 0.7 : 0.5), 0.0, 0.7);
+  final conf = (cov * (calibrated ? 0.7 : 0.5)).clamp(0.0, 0.7);
   return Metric<EnergyFusion>(
     value: EnergyFusion(pts, load, calibrated),
     confidence: conf,

--- a/lib/src/onehz/motion/enmo.dart
+++ b/lib/src/onehz/motion/enmo.dart
@@ -290,7 +290,7 @@ EnmoResult enmoSeries(
   // count the unworn ends too.
   final spanMinutes = minutes.isEmpty ? 0 : keys.last - keys.first + 1;
   final denom = expectedMinutes ?? spanMinutes;
-  final coverage = denom <= 0 ? 0.0 : clamp(covered / denom, 0.0, 1.0);
+  final coverage = denom <= 0 ? 0.0 : (covered / denom).clamp(0.0, 1.0);
   return EnmoResult(ref, minutes, coverage);
 }
 
@@ -405,7 +405,7 @@ Metric<IntensityBands> relativeIntensityBands(
     percentile(moving, 75)!,
     percentile(moving, 90)!,
     // confidence scales with how much moving data anchors the percentiles.
-    clamp(moving.length / 60.0, 0.3, 0.8),
+    (moving.length / 60.0).clamp(0.3, 0.8),
     'RELATIVE within-user intensity (50/75/90th moving pct OF THIS INPUT — '
     'cut-points not frozen); NOT METs',
   );

--- a/lib/src/onehz/motion/orientation.dart
+++ b/lib/src/onehz/motion/orientation.dart
@@ -114,7 +114,7 @@ Metric<Tilt> staticTilt(
     final a = valid[i - 1], b = valid[i];
     final ma = mags[i - 1], mb = mags[i];
     if (ma <= 0 || mb <= 0) continue;
-    final cos = clamp((a.x * b.x + a.y * b.y + a.z * b.z) / (ma * mb), -1.0, 1.0);
+    final cos = ((a.x * b.x + a.y * b.y + a.z * b.z) / (ma * mb)).clamp(-1.0, 1.0);
     rotSum += math.acos(cos) * _rad2deg;
     rotN++;
   }
@@ -137,11 +137,9 @@ Metric<Tilt> staticTilt(
   jitter = mags.length > 1 ? jitter / (mags.length - 1) : 0.0;
   // Stillness is the WORSE of the two — a posture is only as trustworthy as
   // the loosest thing that could have disturbed it.
-  final stillness = clamp(
-    math.min(1.0 - rotDeg / maxRotationDeg, 1.0 - jitter / maxJitterG),
-    0.0,
-    1.0,
-  );
+  final stillness = math
+      .min(1.0 - rotDeg / maxRotationDeg, 1.0 - jitter / maxJitterG)
+      .clamp(0.0, 1.0);
   if (rotDeg > maxRotationDeg) {
     return Metric<Tilt>.absent(
       tier: Tier.high,
@@ -165,7 +163,7 @@ Metric<Tilt> staticTilt(
   final roll = math.atan2(my, mz) * _rad2deg;
   final pos = classifyPosition(pitch, roll);
   // confidence blends stillness with epoch length.
-  final conf = clamp(stillness * (valid.length / 30.0).clamp(0.3, 1.0), 0.0, 0.9);
+  final conf = (stillness * (valid.length / 30.0).clamp(0.3, 1.0)).clamp(0.0, 0.9);
   return Metric<Tilt>(
     value: Tilt(pitch, roll, pos, valid.length, stillness),
     confidence: conf,

--- a/lib/src/onehz/motion/steps.dart
+++ b/lib/src/onehz/motion/steps.dart
@@ -352,7 +352,7 @@ PedometerResult livePedometer(
     if (v < mn) mn = v;
     if (v > mx) mx = v;
   }
-  final conf = clamp(cadence >= 60 && cadence <= 200 ? 0.85 : 0.5, 0.0, 1.0);
+  final conf = (cadence >= 60 && cadence <= 200 ? 0.85 : 0.5).clamp(0.0, 1.0);
   return PedometerResult(steps, durationS, cadence, mx - mn, conf);
 }
 
@@ -515,7 +515,7 @@ double? personalDynFloor(
       if (v.isFinite && v >= 0) v
   ];
   if (xs.length < minMinutes) return null;
-  final q = percentile(xs, clamp(quantile, 0.0, 1.0) * 100.0);
+  final q = percentile(xs, quantile.clamp(0.0, 1.0) * 100.0);
   if (q == null || !q.isFinite || q <= 0) return null;
   return q;
 }
@@ -623,7 +623,7 @@ double? dailyDynSummary(
         m.dynAmp
   ];
   if (xs.length < minCoveredMinutes) return null;
-  final q = percentile(xs, clamp(quantile, 0.0, 1.0) * 100.0);
+  final q = percentile(xs, quantile.clamp(0.0, 1.0) * 100.0);
   if (q == null || !q.isFinite || q <= 0) return null;
   return q;
 }
@@ -787,7 +787,7 @@ Metric<DailyMovementEstimate> dailyActiveMinutes(
   final spanMinutes =
       ((motion.last.tsMinStartMs - motion.first.tsMinStartMs) / 60000).round() + 1;
   final denom = expectedMinutes ?? spanMinutes;
-  final coverage = denom <= 0 ? 0.0 : clamp(covered / denom, 0.0, 1.0);
+  final coverage = denom <= 0 ? 0.0 : (covered / denom).clamp(0.0, 1.0);
   if (covered < dailyStepMinCoveredMinutes) {
     return Metric<DailyMovementEstimate>.absent(
       tier: Tier.estimate,
@@ -866,7 +866,7 @@ Metric<DailyMovementEstimate> dailyActiveMinutes(
   // Upper bound is 0.30, which is what the expression can actually reach —
   // the inner clamp caps at 1.0, so `0.30 * 1.0` is the ceiling. Writing a
   // larger outer bound would imply a confidence this metric never claims.
-  final conf = clamp(0.30 * clamp(coverage / 0.6, 0.3, 1.0), 0.1, 0.30);
+  final conf = (0.30 * (coverage / 0.6).clamp(0.3, 1.0)).clamp(0.1, 0.30);
 
   return Metric<DailyMovementEstimate>(
     value: DailyMovementEstimate(

--- a/lib/src/onehz/respiration/brv_trend.dart
+++ b/lib/src/onehz/respiration/brv_trend.dart
@@ -53,7 +53,7 @@ Metric<BrvResult> breathingRateVariability(List<double> brpm) {
   final cv = m == 0 ? 0.0 : sd / m;
   final slope = theilSen(brpm); // robust trend across the window
   // Confidence grows with window count, capped (MED tier).
-  final conf = clamp(0.3 + 0.05 * brpm.length, 0.3, 0.8);
+  final conf = (0.3 + 0.05 * brpm.length).clamp(0.3, 0.8);
   return Metric<BrvResult>(
     value: BrvResult(
       meanBrpm: m,

--- a/lib/src/onehz/respiration/cvhr_apnea.dart
+++ b/lib/src/onehz/respiration/cvhr_apnea.dart
@@ -183,7 +183,7 @@ Metric<CvhrResult> cvhrApneaScreen(
   }
 
   final perHour = cycleCount / analyzedHours;
-  final conf = clamp((1 - artifactFraction) * 0.85, 0.2, 0.85);
+  final conf = ((1 - artifactFraction) * 0.85).clamp(0.2, 0.85);
   return Metric<CvhrResult>(
     value: CvhrResult(
       cycleCount: cycleCount,
@@ -389,8 +389,7 @@ Metric<CvhrDistribution> cvhrPersonalDistribution(List<CvhrNight> nights) {
     tier: Tier.relative,
     // The floor is 5 nights, so a 5-night answer must not read like a 30-night
     // one. Confidence rises with the nights actually behind it.
-    confidence: clamp(
-        0.3 + 0.4 * (kept.length / cvhrDistributionWindowNights), 0.3, 0.7),
+    confidence: (0.3 + 0.4 * (kept.length / cvhrDistributionWindowNights)).clamp(0.3, 0.7),
     inputs_used: inputs,
     note: 'CVHR is a CARDIAC SURROGATE, not a breathing measurement: this is '
         'how often the pattern showed up across ${kept.length} of your own '

--- a/lib/src/onehz/respiration/relative_odi.dart
+++ b/lib/src/onehz/respiration/relative_odi.dart
@@ -202,7 +202,7 @@ Metric<RelativeOdiResult> relativeOdi(
     }
   }
   final nanCount = relR.where((v) => v.isNaN).length;
-  final conf = clamp(0.5 * validFraction, 0.1, 0.5);
+  final conf = (0.5 * validFraction).clamp(0.1, 0.5);
   return Metric<RelativeOdiResult>(
     value: RelativeOdiResult(
       meanRelR: meanRelR,

--- a/lib/src/onehz/respiration/resp_rate.dart
+++ b/lib/src/onehz/respiration/resp_rate.dart
@@ -304,7 +304,7 @@ Metric<RespEstimate> rsaRespRate(
   final bestPower = peakPwr[best];
   // Confidence: how much of the window agrees with itself, discounted by
   // artifacts. Cap below 1 (PRV ceiling).
-  final conf = clamp((1 - artifactFraction) * consensus, 0.2, 0.9);
+  final conf = ((1 - artifactFraction) * consensus).clamp(0.2, 0.9);
   return Metric<RespEstimate>(
     value: RespEstimate(brpm, bestPeakHz, bestPower, 'rsa'),
     confidence: conf,
@@ -399,7 +399,7 @@ Metric<RespEstimate> riivRespRate(
   final brpm = pk * 60.0;
   final pwr = _powerAt(ls, pk);
   // RIIV from 1 Hz green is MED/relative at best — never high confidence.
-  final conf = clamp(0.6 * validFraction, 0.15, 0.6);
+  final conf = (0.6 * validFraction).clamp(0.15, 0.6);
   return Metric<RespEstimate>(
     value: RespEstimate(brpm, pk, pwr, 'riiv'),
     confidence: conf,
@@ -515,11 +515,7 @@ Metric<FusedResp> fuseRespRate(
   ]);
   final brpm = fused.value ?? rsaV;
   // Agreement boosts confidence above either alone (independent corroboration).
-  final conf = clamp(
-    math.max(rsa.confidence, riiv.confidence) + 0.1,
-    0.2,
-    0.95,
-  );
+  final conf = (math.max(rsa.confidence, riiv.confidence) + 0.1).clamp(0.2, 0.95);
   return Metric<FusedResp>(
     value: FusedResp(
       brpm: brpm,
@@ -539,7 +535,7 @@ Metric<FusedResp> fuseRespRate(
 /// Map a 0..1 confidence to a positive variance for inverse-variance fusion.
 /// Higher confidence => lower variance. Floored so confidence 0 stays finite.
 double _confToVar(double conf) {
-  final c = clamp(conf, 0.05, 1.0);
+  final c = conf.clamp(0.05, 1.0);
   return 1.0 / (c * c);
 }
 

--- a/lib/src/onehz/sleep/cardio_stager.dart
+++ b/lib/src/onehz/sleep/cardio_stager.dart
@@ -243,7 +243,7 @@ class SleepUserProfile {
 
   /// Personal-vs-local blend weight: 0 at cold start → 0.5 hard cap at ≥14
   /// nights (so per-night-local always holds ≥50% of every threshold).
-  double get personalWeight => clamp(nights / 28.0, 0.0, 0.5);
+  double get personalWeight => (nights / 28.0).clamp(0.0, 0.5);
 
   static double? _d(dynamic v) => (v is num) ? v.toDouble() : null;
 
@@ -966,15 +966,12 @@ CardioStagerResult classifyCardioEpochs(
   // HR-relative gates (wake, REM floor, deep trough) had anything to fire on.
   final hrCovConf = nEpoch == 0
       ? 0.0
-      : clamp(
-          [
+      : ([
                 for (final h in hr)
                   if (!h.isNaN) h
               ].length /
-              nEpoch.toDouble(),
-          0.0,
-          1.0);
-  final conf = clamp((0.35 + 0.25 * rrCov) * hrCovConf, 0.15, 0.6);
+              nEpoch.toDouble()).clamp(0.0, 1.0);
+  final conf = ((0.35 + 0.25 * rrCov) * hrCovConf).clamp(0.15, 0.6);
 
   return CardioStagerResult(
     StagerResult(

--- a/lib/src/onehz/sleep/circadian_np.dart
+++ b/lib/src/onehz/sleep/circadian_np.dart
@@ -123,14 +123,14 @@ Metric<CircadianNp> circadianNonparametric(
       : 0.0;
 
   final days = n / epochsPerDay;
-  final conf = clamp(days / 7.0, 0.3, 0.95);
+  final conf = (days / 7.0).clamp(0.3, 0.95);
   return Metric<CircadianNp>(
     value: CircadianNp(
-      interdailyStability: clamp(is_, 0, 1),
+      interdailyStability: is_.clamp(0, 1),
       intradailyVariability: math.max(0, iv),
       m10: m10.value,
       l5: l5.value,
-      relativeAmplitude: clamp(ra, 0, 1),
+      relativeAmplitude: ra.clamp(0, 1),
       m10StartEpoch: m10.start,
       l5StartEpoch: l5.start,
     ),

--- a/lib/src/onehz/sleep/nap.dart
+++ b/lib/src/onehz/sleep/nap.dart
@@ -455,7 +455,7 @@ Metric<List<NapWindow>> detectNaps(
     // Confidence, NOT efficiency. A 20% dip below the awake baseline earns
     // full marks on that axis; the rest rewards evidence, not sleep quality.
     // Capped at 0.85 — this is a wrist estimate and never becomes a fact.
-    final dipScore = clamp((baseline - medHr) / (baseline * 0.20), 0, 1);
+    final dipScore = ((baseline - medHr) / (baseline * 0.20)).clamp(0, 1);
     final stillScore = tib <= 0 ? 0.0 : tst / tib;
     // Wear corroboration for THIS bout, not for the day. A day-global
     // `wristOff.isNotEmpty` flag rewarded every nap on a day the band happened
@@ -463,16 +463,12 @@ Metric<List<NapWindow>> detectNaps(
     // day it never came off — backwards on both counts. This scores how much of
     // THIS bout is contradicted by an off-body span: none → full marks.
     final worstOff = offFrac > exFrac ? offFrac : exFrac;
-    final corroborated = clamp(1 - worstOff / maxNapOffWristFraction, 0, 1);
-    final conf = clamp(
-      0.20 +
+    final corroborated = (1 - worstOff / maxNapOffWristFraction).clamp(0, 1);
+    final conf = (0.20 +
           0.30 * dipScore +
           0.25 * coverage +
           0.15 * stillScore +
-          0.10 * corroborated,
-      0.2,
-      0.85,
-    );
+          0.10 * corroborated).clamp(0.2, 0.85);
 
     naps.add(NapWindow(
       startSec: aStart - baseSec,

--- a/lib/src/onehz/sleep/night_hrv_shape.dart
+++ b/lib/src/onehz/sleep/night_hrv_shape.dart
@@ -202,11 +202,7 @@ Metric<NightHrvShape> nightHrvShape(
     ),
     // Bounded by how many bins actually carried beats — a night that abstained
     // on half its bins is not a shape you can read.
-    confidence: clamp(
-      0.8 * bins.where((b) => b.present).length / bins.length,
-      0.0,
-      0.8,
-    ),
+    confidence: (0.8 * bins.where((b) => b.present).length / bins.length).clamp(0.0, 0.8),
     tier: Tier.high,
     inputs_used: inputs,
     note: 'per-bin RMSSD (${binMin.round()}-min bins, PRV not ECG-HRV) — a '

--- a/lib/src/onehz/sleep/segment.dart
+++ b/lib/src/onehz/sleep/segment.dart
@@ -142,7 +142,7 @@ class StageInterval {
   required int tstSec,
   required double confidence,
 }) {
-  final t = clamp(confidence / kMaxSleepConfidence, 0.0, 1.0);
+  final t = (confidence / kMaxSleepConfidence).clamp(0.0, 1.0);
   double rel(double best, double worst) => worst + (best - worst) * t;
   final deepHalf = math.max(
     (rel(_deepRelHalfBest, _deepRelHalfWorst) * deepSec).round(),
@@ -669,8 +669,8 @@ SleepSegmentation segmentSleep(
   for (final b in rr) {
     if (b.ts >= chosen.start && b.ts < chosen.end) rrSeconds.add(b.ts);
   }
-  final hrCov = clamp(hrCovered / inBed, 0.0, 1.0);
-  final rrCov = clamp(rrSeconds.length / inBed, 0.0, 1.0);
+  final hrCov = (hrCovered / inBed).clamp(0.0, 1.0);
+  final rrCov = (rrSeconds.length / inBed).clamp(0.0, 1.0);
   final stagingConf = (0.35 + 0.25 * rrCov) * hrCov;
   // Confidence in the window WE PUBLISHED, on van Hees' own construction
   // (length up to a typical 7 h night, clamped) — but measured on `chosen`, the
@@ -679,9 +679,9 @@ SleepSegmentation segmentSleep(
   // file never reads. Half of every night's published confidence came from the
   // detector that lost, and that confidence sets the SLP-13 stage-interval
   // widths.
-  final windowConf = clamp(inBed / (7 * 3600), 0.3, 0.95);
+  final windowConf = (inBed / (7 * 3600)).clamp(0.3, 0.95);
   final conf =
-      clamp((windowConf + stagingConf) / 2.0, 0.0, kMaxSleepConfidence);
+      ((windowConf + stagingConf) / 2.0).clamp(0.0, kMaxSleepConfidence);
 
   return SleepSegmentation(
     window: SleepWindow(

--- a/lib/src/onehz/sleep/sri.dart
+++ b/lib/src/onehz/sleep/sri.dart
@@ -138,7 +138,7 @@ Metric<SriResult> phillipsSri(
   final sri = 200.0 * agreement / cases - 100.0;
   // Confidence: scales with the number of day-comparisons (more days, more
   // stable). Saturates around a typical 7-day record.
-  final conf = clamp((days - 1) / 7.0, 0.3, 0.95);
+  final conf = ((days - 1) / 7.0).clamp(0.3, 0.95);
   return Metric<SriResult>(
     value: SriResult(sri, days, cases, pairs),
     confidence: conf,

--- a/lib/src/onehz/sleep/van_hees.dart
+++ b/lib/src/onehz/sleep/van_hees.dart
@@ -414,7 +414,7 @@ Metric<SleepWindow> vanHeesSleepWindow(
   final undecidableSec = (unresolved * cadence).round();
 
   // Confidence grows with the detected SPT length up to a typical night.
-  final conf = clamp(sptSec / (7 * 3600), 0.3, 0.95);
+  final conf = (sptSec / (7 * 3600)).clamp(0.3, 0.95);
   return Metric<SleepWindow>(
     value: SleepWindow(
       onsetIdx: bestStart,

--- a/lib/src/onehz/util.dart
+++ b/lib/src/onehz/util.dart
@@ -185,8 +185,6 @@ double? z(double x, List<double> sample) {
   return (x - m) / sd;
 }
 
-double clamp(double x, double lo, double hi) => math.max(lo, math.min(hi, x));
-
 /// Ordinary-least-squares slope of y vs x (x defaults to 0..n-1). Null if <2.
 double? olsSlope(List<double> y, [List<double>? x]) {
   final n = y.length;
@@ -471,7 +469,7 @@ double normalTwoSidedP(double zScore) {
                                                                   t *
                                                                       (-0.82215223 +
                                                                           t * 0.17087277)))))))));
-  return clamp(ans, 0.0, 1.0);
+  return ans.clamp(0.0, 1.0);
 }
 
 /// Benjamini-Hochberg (1995) step-up FDR adjustment over a family of p-values.

--- a/lib/src/onehz/wellness/anomaly.dart
+++ b/lib/src/onehz/wellness/anomaly.dart
@@ -328,7 +328,7 @@ List<List<double>> _robustCorr(
         final xa = [for (final s in std) s[a]];
         final xb = [for (final s in std) s[b]];
         final r = _corr(xa, xb);
-        final rc = clamp(r ?? 0.0, -0.95, 0.95);
+        final rc = (r ?? 0.0).clamp(-0.95, 0.95);
         m[a][b] = rc;
         m[b][a] = rc;
       }

--- a/lib/src/onehz/wellness/cycle_lengths.dart
+++ b/lib/src/onehz/wellness/cycle_lengths.dart
@@ -29,7 +29,6 @@
 // that this is a prompt to ask a clinician, not an answer.
 
 import '../types.dart';
-import '../util.dart';
 
 /// Consecutive-cycle difference used by the published criteria, in days.
 const int cycleLengthDifferenceCriterionDays = 7;
@@ -137,7 +136,7 @@ Metric<CycleLengthSeries> cycleLengthSeries(
       maxConsecutiveDifferenceDays: diffs.reduce((a, b) => a > b ? a : b),
       longestIntervalDays: lengths.reduce((a, b) => a > b ? a : b),
     ),
-    confidence: clamp(lengths.length / 24.0, 0.3, 0.8),
+    confidence: (lengths.length / 24.0).clamp(0.3, 0.8),
     tier: Tier.high,
     inputs_used: inputs,
     note: caveat,

--- a/lib/src/onehz/wellness/readiness_composite.dart
+++ b/lib/src/onehz/wellness/readiness_composite.dart
@@ -286,7 +286,7 @@ Metric<Readiness> readinessComposite(
   final score = 100 / (1 + math.exp(-composite));
 
   // Confidence scales with how many inputs were available (more = better).
-  final conf = clamp(0.3 + 0.15 * used.length, 0.3, 0.9);
+  final conf = (0.3 + 0.15 * used.length).clamp(0.3, 0.9);
 
   return Metric<Readiness>(
     value: Readiness(score, composite),

--- a/lib/src/onehz/wellness/temp_circadian.dart
+++ b/lib/src/onehz/wellness/temp_circadian.dart
@@ -200,7 +200,7 @@ Metric<SettledSkinTemp> nightlySkinTemp(
   }
   return Metric<SettledSkinTemp>(
     value: SettledSkinTemp(mean(kept)!, frac, cal.unit),
-    confidence: clamp(frac, 0.0, 1.0),
+    confidence: frac.clamp(0.0, 1.0),
     tier: Tier.relative,
     inputs_used: inputs,
     note: 'RELATIVE nightly skin-temp mean over the SETTLED portion only '
@@ -289,7 +289,7 @@ Metric<TempCircadian> tempCircadian(
   }
 
   // Confidence: tie to cosinor R² when present, else a modest np-only value.
-  final conf = cos.value != null ? clamp(cos.value!.r2, 0.1, 0.9) : 0.3;
+  final conf = cos.value != null ? (cos.value!.r2).clamp(0.1, 0.9) : 0.3;
   return Metric<TempCircadian>(
     value: TempCircadian(cos.value, np, cal.unit),
     confidence: conf,
@@ -387,7 +387,7 @@ CircadianNonparam? _nonparam(
     }
     profVar /= profile.length;
   }
-  final is_ = varTot > 0 ? clamp(profVar / (varTot / p), 0, 1) : 0.0;
+  final is_ = varTot > 0 ? (profVar / (varTot / p)).clamp(0, 1).toDouble() : 0.0;
 
   // M10 / L5 / RA are DELIBERATELY NOT COMPUTED. See the file header: the temp
   // series that survives retention is median-centred, so it is signed, and

--- a/lib/src/onehz/workout/hr_recovery.dart
+++ b/lib/src/onehz/workout/hr_recovery.dart
@@ -315,11 +315,10 @@ Metric<HrRecovery> hrRecovery(
   // we have no way to know the recovery sample is really 60 s later. A
   // timestamped tail too sparse to fill the peak window doesn't earn it either
   // — the timestamps proved the window was short rather than fixing it.
-  final conf = clamp(
-    0.3 + 0.4 * validFrac + (times != null && peakWindowFull ? 0.2 : 0.0),
-    0.2,
-    0.9,
-  );
+  final conf = (0.3 +
+          0.4 * validFrac +
+          (times != null && peakWindowFull ? 0.2 : 0.0))
+      .clamp(0.2, 0.9);
 
   // TAU (CV-08). Same tail, same slice, no second pass over the substrate.
   // Timestamps are REQUIRED: a time constant fitted to array positions of

--- a/lib/src/onehz/workout/observed_max_hr.dart
+++ b/lib/src/onehz/workout/observed_max_hr.dart
@@ -143,10 +143,16 @@ Metric<HrCeiling> sessionHrCeiling(
 
   final holdMs = holdSeconds * 1000.0;
   final gapMs = maxGapSeconds * 1000.0;
+  // A real held effort's corroborating motion is not necessarily even across
+  // the hold (e.g. a couple of seconds of arm swing at each end of a quiet
+  // middle), so a start that fails the motion gate on the MINIMAL qualifying
+  // window still gets to extend further before giving up — capped, so one
+  // quiet start can't turn this into an O(n²) scan of a whole day.
+  final maxSpanMs = holdMs * 4;
   HrCeiling? best;
-  // ponytail: O(n · holdSeconds) — one session at 1 Hz, so ~15 passes over a
-  // few thousand samples. A monotonic-deque sliding minimum if it ever runs
-  // over a whole day.
+  // ponytail: O(n · holdSeconds) — one session at 1 Hz, so a bounded number of
+  // passes over a few thousand samples. A monotonic-deque sliding minimum if
+  // it ever runs over a whole day.
   for (var i = 0; i < rows.length; i++) {
     var lo = rows[i].hr;
     var motionSum = 0.0;
@@ -158,19 +164,22 @@ Metric<HrCeiling> sessionHrCeiling(
       count++;
       final span = rows[j].ts - rows[i].ts;
       if (span < holdMs) continue;
-      // The window qualifies on duration. `lo` is the bpm sustained across all
-      // of it; extending further can only lower it, so this is the best this
-      // start can do and we stop.
+      if (span > maxSpanMs) break; // gave this start its fair shot
+      // The window qualifies on duration. `lo` is the bpm sustained across
+      // all of it. Only stop once the motion actually corroborates — that's
+      // the earliest point extending further can only lower `lo` for no gain.
       final motion = motionSum / count;
-      if (motion >= gate && (best == null || lo > best.bpm)) {
-        best = HrCeiling(
-          bpm: lo,
-          tsMs: rows[i].ts,
-          heldSeconds: (span / 1000).round(),
-          motionG: motion,
-        );
+      if (motion >= gate) {
+        if (best == null || lo > best.bpm) {
+          best = HrCeiling(
+            bpm: lo,
+            tsMs: rows[i].ts,
+            heldSeconds: (span / 1000).round(),
+            motionG: motion,
+          );
+        }
+        break;
       }
-      break;
     }
   }
 
@@ -183,7 +192,7 @@ Metric<HrCeiling> sessionHrCeiling(
   }
   return Metric<HrCeiling>(
     value: best,
-    confidence: clamp(best.heldSeconds / (holdSeconds * 2.0), 0.3, 0.8),
+    confidence: (best.heldSeconds / (holdSeconds * 2.0)).clamp(0.3, 0.8),
     tier: Tier.high,
     inputs_used: inputs,
     note: 'OBSERVED ceiling, not physiological HRmax — an underestimate if you '

--- a/test/onehz/observed_max_hr_test.dart
+++ b/test/onehz/observed_max_hr_test.dart
@@ -66,6 +66,28 @@ void main() {
       }
     });
 
+    test('motion split across the ends of a long hold still counts', () {
+      // Two 3 s bursts of arm swing bracketing a quiet middle. Neither burst
+      // alone clears the gate once padded out to a 15 s window (0.076 avg),
+      // but the full ~19 s span between them does (0.101 avg) — the minimal
+      // 15 s window from any single start index can never see both bursts at
+      // once, so a corroborated hold that's real gets missed unless a start
+      // is allowed to keep extending past its first duration-qualifying
+      // window when that window's motion doesn't (yet) pass the gate.
+      const bpm = 180.0;
+      final hr = <HrSample>[];
+      final accel = <AccelSample>[];
+      for (var i = 0; i < 21; i++) {
+        final t = i * 1000.0;
+        final dev = (i <= 2 || i >= 18) ? 0.4 : 0.001;
+        hr.add(HrSample(t, bpm));
+        accel.add(AccelSample(t, 0, 0, 1.0 + dev));
+      }
+      final m = sessionHrCeiling(hr, accel, deviceFamily: 'gen4');
+      expect(m.present, isTrue);
+      expect(m.value!.bpm, bpm);
+    });
+
     test('a gap in the stream breaks the hold', () {
       final a = _run(0, 10, 180, 0.20);
       final b = _run(60000, 10, 180, 0.20); // 50 s later

--- a/test/onehz/util_test.dart
+++ b/test/onehz/util_test.dart
@@ -36,9 +36,9 @@ void main() {
     });
 
     test('clamp', () {
-      expect(clamp(5, 0, 3), 3);
-      expect(clamp(-1, 0, 3), 0);
-      expect(clamp(2, 0, 3), 2);
+      expect(5.clamp(0, 3), 3);
+      expect((-1).clamp(0, 3), 0);
+      expect(2.clamp(0, 3), 2);
     });
   });
 


### PR DESCRIPTION
few unrelated cleanups from an audit pass:

- sessionHrCeiling (observed_max_hr.dart) was giving up on a start index the moment its minimal 15s window failed the motion gate, even if a longer window from the same start would've passed. a real held effort where the corroborating motion is at the edges (arm swing at the start/end of a hold, quiet in the middle) was getting silently missed instead of setting the ceiling. now it keeps extending the window (capped at 4x holdSeconds so it can't blow up on a long quiet stretch) until the motion actually corroborates. added a test for the uneven-motion case.

- util.dart had its own free-standing `clamp()` next to Dart's built-in `num.clamp()`, and both spellings were in use in the same files. deleted the custom one, moved every call site to the stdlib version. num.clamp() returns `num` not `double` even when called on a double, so a few spots needed a `.toDouble()` to keep the types honest - fixed those too.

- readme: the "290 tests" line was stale (real count's higher and just going to keep drifting), dropped the hardcoded number since the CI badge already shows live status. also added a short section naming protocol/analytics/edge up front since right now you only find out about the three-repo split by opening CONTRIBUTING.md.

dart test: 625 passed, 6 skipped (missing real-capture fixture, pre-existing, unrelated to this).

## Summary by Sourcery

Improve observed heart-rate ceiling detection for uneven-motion holds and standardize numeric clamping across the analytics codebase.

Bug Fixes:
- Allow observed heart-rate ceiling detection to continue extending qualifying holds until motion corroboration is found, capturing efforts with uneven motion across the hold.
- Replace the custom clamp helper with Dart's standard numeric clamp while preserving expected numeric types.

Enhancements:
- Improve project README guidance by explaining the roles of the protocol, analytics, and edge repositories and removing the stale hardcoded test count.

Documentation:
- Clarify the repository's position in the broader data pipeline and point contributors to the appropriate repository for protocol changes.

Tests:
- Add coverage for held efforts whose motion evidence is split across the beginning and end of the hold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved maximum heart-rate detection for long holds where motion occurs intermittently, including activity at the beginning and end of the hold.
  * Added coverage for split-motion scenarios to help ensure these heart-rate ceilings are recognized correctly.

* **Documentation**
  * Clarified how the protocol, analytics, and edge pipeline fit together.
  * Updated testing guidance to reflect current coverage without relying on a fixed test count.

* **Refactor**
  * Standardized numeric value limiting across health and wellness calculations without changing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->