### PR TITLE
Extract dispersion-below-quantum guard (multi-device prep)

### DIFF
--- a/lib/src/onehz/foundations/baseline.dart
+++ b/lib/src/onehz/foundations/baseline.dart
@@ -73,6 +73,23 @@ RobustBaseline robustBaseline(List<double> window, {int minValid = 3}) {
   );
 }
 
+/// Whether [base]'s dispersion is too coarse for the instrument that produced
+/// it. [quantum] is the input's own quantization step (1.0 for whole-bpm RHR,
+/// 1.0 for an integer skin-temp ADC count); 0 means "not quantized, no guard".
+/// TRUE = refuse; there is nothing to standardize against.
+///
+/// Extracted verbatim from `readiness_composite.dart`'s refusal (see that
+/// file's comment for why it is NOT gated on `robustZ == null`: MAD can
+/// collapse to zero on a quantized baseline whose SD is still nonzero-but-tiny
+/// — a 14-night whole-bpm baseline alternating 58/59 has MAD 0.5 (robustZ
+/// succeeds) but SD ~0.52, exactly the unresolvable-dispersion case this
+/// exists to catch).
+bool dispersionBelowQuantum(List<double> base, double quantum) {
+  if (quantum <= 0) return false;
+  final sd = stddev(base);
+  return sd == null || sd < quantum;
+}
+
 /// Minimal Detectable Change: MDC = 1.96 × √2 × typical-error.
 /// We approximate the typical error by the baseline scale unless a measured
 /// [typicalError] is supplied. Returns null if no dispersion is known.

--- a/lib/src/onehz/wellness/readiness_composite.dart
+++ b/lib/src/onehz/wellness/readiness_composite.dart
@@ -34,6 +34,7 @@
 // every score carries its drivers; never names a driver below its MDC.
 
 import 'dart:math' as math;
+import '../foundations/baseline.dart' show dispersionBelowQuantum;
 import '../types.dart';
 import '../util.dart';
 import 'temp_circadian.dart' show kMinSettledFraction;
@@ -217,8 +218,8 @@ Metric<Readiness> readinessComposite(
       // NOT a synthetic floor and NOT a clamp: nothing is substituted for the
       // missing dispersion. Scoped to the fallback on purpose — MAD > 0 on a
       // quantized series already means ≥ 1 step of spread.
-      final sd = stddev(base);
-      if (sd == null || sd < inp.quantum) {
+      if (dispersionBelowQuantum(base, inp.quantum)) {
+        final sd = stddev(base);
         refusals.add('${inp.label}: baseline_dispersion_below_quantum:'
             'sd=${sd == null ? 'null' : round6(sd)},'
             'quantum=${round6(inp.quantum)},n=${base.length}');

--- a/test/dispersion_guard_test.dart
+++ b/test/dispersion_guard_test.dart
@@ -17,6 +17,11 @@ void main() {
       expect(dispersionBelowQuantum([58, 59, 58, 60, 57], 1), isFalse);
     });
 
+    test('SD exactly equal to quantum does not refuse (strict sd < quantum)',
+        () {
+      expect(dispersionBelowQuantum([0, 1, 2], 1), isFalse);
+    });
+
     test('quantum 0 (an unquantized input) never refuses', () {
       expect(dispersionBelowQuantum([58, 58, 59], 0), isFalse);
       expect(dispersionBelowQuantum([], 0), isFalse);
@@ -41,8 +46,11 @@ void main() {
       final m = readinessComposite([rhrInput(52.0, base)],
           minInputs: 1, minWeightSum: 0.0);
       expect(m.present, isFalse);
-      expect(m.note, contains('RHR: baseline_dispersion_below_quantum:'));
-      expect(m.note, contains('quantum=1'));
+      expect(
+          m.note,
+          equals('no readiness inputs present — "—" (never imputed). '
+              'Refused: RHR: baseline_dispersion_below_quantum:'
+              'sd=0.267261,quantum=1.0,n=14.'));
     });
   });
 }

--- a/test/dispersion_guard_test.dart
+++ b/test/dispersion_guard_test.dart
@@ -1,0 +1,48 @@
+// M0 §0.1: dispersionBelowQuantum, extracted verbatim from
+// readiness_composite.dart's inline refusal so the same guard can be reused
+// by illness_cusum.dart / anomaly.dart in a LATER milestone (M5 — extending
+// it now would change a shipped number for quantized-SD-between-0-and-1
+// users on a milestone whose gate forbids any kAlgoVersion bump).
+
+import 'package:test/test.dart';
+import 'package:openstrap_analytics/onehz.dart';
+
+void main() {
+  group('dispersionBelowQuantum', () {
+    test('a 3-value baseline with SD 0.577 (quantum 1) refuses', () {
+      expect(dispersionBelowQuantum([58, 58, 59], 1), isTrue);
+    });
+
+    test('a 5-value baseline with SD >= 1 does not refuse', () {
+      expect(dispersionBelowQuantum([58, 59, 58, 60, 57], 1), isFalse);
+    });
+
+    test('quantum 0 (an unquantized input) never refuses', () {
+      expect(dispersionBelowQuantum([58, 58, 59], 0), isFalse);
+      expect(dispersionBelowQuantum([], 0), isFalse);
+    });
+
+    test('an empty baseline (SD null) with a real quantum refuses', () {
+      expect(dispersionBelowQuantum([], 1), isTrue);
+    });
+  });
+
+  group('readinessComposite still emits the byte-identical refusal string',
+      () {
+    test('a 14-night sub-bpm baseline refuses by name via the extracted '
+        'guard', () {
+      // Same case as wellness_test.dart's "A4 — a 14-night baseline with
+      // sub-bpm dispersion is REFUSED by name" — pinned here too because this
+      // is the string the edge UI reads, and this file is what proves the
+      // extraction changed nothing about it.
+      final base = <double>[
+        58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 59
+      ];
+      final m = readinessComposite([rhrInput(52.0, base)],
+          minInputs: 1, minWeightSum: 0.0);
+      expect(m.present, isFalse);
+      expect(m.note, contains('RHR: baseline_dispersion_below_quantum:'));
+      expect(m.note, contains('quantum=1'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Single prerequisite commit for the OpenStrap/edge any-wearable multi-device support work (see edge PR). Hoists the baseline-dispersion refusal out of `readiness_composite.dart`'s inline guard into a standalone, reusable predicate (`dispersionBelowQuantum` in `foundations/baseline.dart`), so a later milestone can reuse the same guard on `illness_cusum.dart`/`anomaly.dart` once per-device masking shortens their baseline windows.

- No behavior change today: the extracted function is the inline body verbatim, byte-identical refusal string.
- The guard is NOT yet added to illness_cusum/anomaly here — doing so would change a shipped number for a single-device user whose quantized baseline SD sits strictly between 0 and 1, which this commit deliberately avoids.

## Test plan
- [x] `dart test`: 632 passed, 0 failed (6 pre-existing skips, fixture-gated), dart analyze clean, no golden churn
- [x] New `test/dispersion_guard_test.dart` pins 3 unit cases + 1 readinessComposite integration case

## Summary by Sourcery

Extract the baseline-dispersion refusal guard for reuse without changing existing readiness results.

Enhancements:
- Extract the baseline-dispersion quantum guard into a reusable foundation predicate while preserving current readiness behavior and refusal output.

Tests:
- Add unit and integration coverage for quantization thresholds, unquantized inputs, empty baselines, and the unchanged readiness refusal message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness calculations for quantized baseline data with insufficient variation.
  * Preserved the appropriate refusal status and diagnostic message when baseline dispersion falls below the configured quantum.
  * Added consistent handling for unquantized, empty, and adequately varied baseline data, ensuring readiness results remain stable across these scenarios.

* **Tests**
  * Added coverage for dispersion thresholds and readiness behavior with low-variation baseline data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->